### PR TITLE
refresh browser on handshake with peer

### DIFF
--- a/lib/saito/peer.js
+++ b/lib/saito/peer.js
@@ -11,6 +11,7 @@ class Peer {
     this.peer.host 			= "localhost";
     this.peer.port 			= "12101";
     this.peer.publickey 		= "";
+    this.peer.version       = "";
     this.peer.protocol 			= "http";
     this.peer.synctype 			= "full";         // full = full blocks
 							  // lite = lite blocks
@@ -76,7 +77,7 @@ class Peer {
       //
       // handshake reset every time
       //
-      this.peer.handshake
+      this.peer.handshake;
 
     }
 
@@ -133,9 +134,10 @@ class Peer {
         handshake.peer			= {}; // my info
         handshake.peer.host		= "";
         handshake.peer.port		= "";
-        handshake.peer.protocol		= "";
-        handshake.peer.endpoint		= {};
-        handshake.peer.publickey 	= this.app.wallet.returnPublicKey();
+        handshake.peer.protocol   = "";
+        handshake.peer.endpoint   = {};
+        handshake.peer.publickey  = this.app.wallet.returnPublicKey();
+        handshake.peer.version   = this.app.wallet.wallet.version;
         handshake.peer.synctype		= "full";
 
         handshake.peer.sendblks		= 1;
@@ -208,14 +210,16 @@ class Peer {
         delete this.socket;
         this.socket = null;
       }
-
-      this.socket = io.connect(`${this.peer.protocol}://${this.peer.host}:${this.peer.port}`, {
+      
+      this.socket = io({
         reconnection: true,
         reconnectionDelay: 1000,
         reconnectionDelayMax: 5000,
         reconnectionAttempts: Infinity,
         transports: ['websocket']
       });
+
+      this.socket = io.connect(`${this.peer.protocol}://${this.peer.host}:${this.peer.port}`);
 
       this.addSocketEvents();
 
@@ -313,6 +317,7 @@ class Peer {
 
 
         console.log("socket connection has fired!");
+        if (this.app.BROWSER == 1) { salert('Socket Connect'); }
 
         //
         // inform event channel
@@ -334,6 +339,25 @@ class Peer {
       this.socket.on('disconnect', () => {
         this.app.connection.emit('connection_down', this);
         this.app.connection.emit('peer_disconnect', this);
+        if (this.app.BROWSER == 1) { salert('Socket Disconnnect'); }
+      });
+
+      this.socket.on('reconnect', () => {
+        //
+        // initiate handshake
+        //
+        this.handshake.step               = 1;
+        this.handshake.ts                 = new Date().getTime();
+        this.handshake.attempts++;
+        this.sendRequest("handshake", this.handshake);
+
+        console.log("socket reconnection has fired!");
+
+        //
+        // inform event channel
+        //
+        this.app.connection.emit('connection_up', this);
+        if (this.app.BROWSER == 1) { salert('Socket Reconnect'); }
       });
 
 
@@ -433,52 +457,58 @@ class Peer {
 
     }
 
-// console.log("PEERSHAKE: " + JSON.stringify(peershake));
+    // console.log("PEERSHAKE: " + JSON.stringify(peershake));
 
     if (this.peer.modules == undefined) { this.peer.modules = []; }
     for (let i = 0; i < peershake.modules.length; i++) {
 
-// console.log("HERE: " + JSON.stringify(this.peer));
+      // console.log("HERE: " + JSON.stringify(this.peer));
 
       if (!this.peer.modules.includes(peershake.modules[i])) {
-	this.peer.modules.push(peershake.modules[i]);
+        this.peer.modules.push(peershake.modules[i]);
       }
     }
 
     //
     // basic peer data
     //
-    this.peer.receiveblks		= peershake.peer.sendblks;
-    this.peer.receivetxs		= peershake.peer.sendtxs;
-    this.peer.receivegts		= peershake.peer.sendgts;
+    this.peer.receiveblks = peershake.peer.sendblks;
+    this.peer.receivetxs = peershake.peer.sendtxs;
+    this.peer.receivegts = peershake.peer.sendgts;
 
     // this.peer.sendblks		= peershake.peer.receiveblks;
-    this.peer.sendtxs		  	= peershake.peer.receivetxs;
-    this.peer.sendgts		  	= peershake.peer.receivegts;
+    this.peer.sendtxs = peershake.peer.receivetxs;
+    this.peer.sendgts = peershake.peer.receivegts;
 
     if (this.peer.publickey == "") {
-      this.peer.publickey 		= peershake.peer.publickey;
+      this.peer.publickey = peershake.peer.publickey;
     }
 
-    this.peer.host			= peershake.peer.host;
-    this.peer.port			= peershake.peer.port;
-    this.peer.protocol			= peershake.peer.protocol;
-    this.peer.synctype			= peershake.peer.synctype
-    this.peer.endpoint			= peershake.peer.endpoint;
-    this.peer.keylist 			= peershake.peer.keylist;
-    this.peer.name           = peershake.peer.name;
+    this.peer.host = peershake.peer.host;
+    this.peer.port = peershake.peer.port;
+    this.peer.protocol = peershake.peer.protocol;
+    this.peer.synctype = peershake.peer.synctype
+    this.peer.endpoint = peershake.peer.endpoint;
+    this.peer.keylist = peershake.peer.keylist;
+    this.peer.name = peershake.peer.name;
 
     //
     // browsers get lite-client
     //
-    if (this.app.BROWSER == 1) { this.peer.synctype = "lite"; }
-
+    if (this.app.BROWSER == 1) { 
+      this.peer.synctype = "lite";
+      // refresh the browser if I am handshaking with a higher versioned peer.
+      // right now we are assuming peers are truthful.
+      if (this.app.wallet.wallet.version < peershake.peer.version) {
+        window.location = window.location;
+      }
+    }
     //
     // verification sigs
     //
     if (this.handshake.challenge_proof == "" && peershake.challenge_mine != "") {
-      this.handshake.challenge_peer       = peershake.challenge_mine;
-      this.handshake.challenge_proof      = this.app.crypto.signMessage("_" + this.handshake.challenge_peer, this.app.wallet.returnPrivateKey());
+      this.handshake.challenge_peer = peershake.challenge_mine;
+      this.handshake.challenge_proof = this.app.crypto.signMessage("_" + this.handshake.challenge_peer, this.app.wallet.returnPrivateKey());
     }
 
     if (this.handshake.challenge_mine != "" && peershake.challenge_proof != "" && this.handshake.challenge_verified == 0) {
@@ -489,23 +519,29 @@ class Peer {
       // this accepts publickey at face value, what about endpoint or hostile peer swap?
       //
       if (this.app.crypto.verifyMessage("_" + this.handshake.challenge_mine, peershake.challenge_proof, peershake.peer.publickey) == 0) {
+
       } else {
 
         this.peer.publickey = peershake.peer.publickey;
 
         this.handshake.challenge_verified = 1;
 
+        
+
+      }
+
+
         // we have verified all necessary info, send event
         this.app.connection.emit("handshake_complete", this);
-      }
+      
     }
 
     //
     // check blockchain
     //
-    let peer_last_bid 			= peershake.blockchain.last_bid;
-    let peer_forkid 			= peershake.blockchain.fork_id;
-    let peer_genesis_bid 		= peershake.blockchain_genesis_bid;
+    let peer_last_bid = peershake.blockchain.last_bid;
+    let peer_forkid = peershake.blockchain.fork_id;
+    let peer_genesis_bid = peershake.blockchain_genesis_bid;
 
     // 
     // if peer is ahead of me, let modules know latest block
@@ -530,7 +566,7 @@ class Peer {
     let last_shared_bid = this.app.blockchain.returnLastSharedBlockId(peer_forkid, peer_last_bid);
     if (my_last_bid > last_shared_bid) {
 
-      if (peer_last_bid - my_last_bid > this.app.blockchain.genesis_period && peer_last_bid != 0 && this.peer.synctype == "full") {	
+      if (peer_last_bid - my_last_bid > this.app.blockchain.genesis_period && peer_last_bid != 0 && this.peer.synctype == "full") {
 
         //
         // TODO - don't exit - fully off chain
@@ -577,7 +613,7 @@ class Peer {
       this.handshake.attempts++;
     }
     if (this.handshake.step <= 3) {
-      this.handshake.step = peershake.step+1;
+      this.handshake.step = peershake.step + 1;
       this.sendRequest("handshake", this.handshake);
     }
 

--- a/lib/saito/wallet.js
+++ b/lib/saito/wallet.js
@@ -26,7 +26,7 @@ class Wallet {
     this.wallet.outputs                  = [];
     this.wallet.spends                   = [];        // spent but still around
     this.wallet.default_fee              = 2;
-    this.wallet.version                  = 3.012;
+    this.wallet.version                  = 3.014;
     this.wallet.pending                  = [];       // sent but not seen
 
     this.inputs_hmap                     = [];


### PR DESCRIPTION
David - can you sanity check this.

Added version to handshake peer object and optimistically refresh the browser if handshaking with a higher versioned peer.

Spoofing version could be used as a client level attack - but don't think it makes sense to protect against this rightnow.