### PR TITLE
fix initial player queue

### DIFF
--- a/mods/scotland/scotland.js
+++ b/mods/scotland/scotland.js
@@ -474,9 +474,9 @@ class Scotland extends GameTemplate {
 	      let skip_x_bonus = 0;
 
 	      for (let z = 1; z <= this.number_of_detectives; z++) {
-	        if ((i+1) > this.game.state.x) { skip_x_gamer = 1+fake_detectives; }
-	        this.game.queue.push(("play\t"+(i+1)+skip_x_gamer)+"\t"+(i+1));
-	        fake_detectives++;
+	        if (z == this.game.state.x) { skip_x_bonus = 1; }
+	        this.game.queue.push(("play\t"+(z+skip_x_bonus))+"\t"+(i+1));
+	        // fake_detectives++;
               }
 
 	    }


### PR DESCRIPTION
Game won't move past the first movement of mister X.
example of error: ["round","play\t21\t2","play\t22\t2","play\t23\t2","play\t24\t2","play\t25\t2"]