### PR TITLE
Improved responsive layout, fixed footer icons and Chinese link

### DIFF
--- a/mods/website/web/index.html
+++ b/mods/website/web/index.html
@@ -70,8 +70,8 @@
   <div class="all">
     <div class="alert">
       <span data-il8n="saito_available_1">SAITO is now available for purchase:</span><span><a
-          href="#get_saito" data-il8n="saito_available_2">details here</a></span><span
-        data-il8n="saito_available_3">.</span>
+          href="#get_saito" data-il8n="saito_available_2">details here</a></span><!--span
+        data-il8n="saito_available_3">.</span-->
     </div>
     <div class="sectionWrapper1">
 
@@ -91,14 +91,14 @@
             Twitter, Facebook and Amazon without the need for monopolies like Google or Infura in the network layer.
           </div>
           <div class="crumbs">
-            <a id="whitepaperLink" href="/saito-whitepaper.pdf" class="link" data-il8n="whitepaper">Read the Saito
-              Whitepaper</a>
+            <a id="whitepaperLink" href="/saito-whitepaper.pdf" class="link" data-il8n="whitepaper">Whitepaper</a>
             <!---
             <span>|</span>
             <a id="litepaperLink" href="/saito-litepaper.pdf" class="link" data-il8n="litepaper">Litepaper</a>
 --->
           </div>
-          <div class="littleIcon">
+          
+          <div class="littleIcon mobile">
             <a class="itemImage far fa-envelope website-newsletter-subscribe" title="Subscribe to our Newsletter"></a>
             <a id="weixin-link">
               <i class="itemImage fab fa-weixin" aria-hidden="true"></i>
@@ -119,9 +119,11 @@
               <i class="itemImage fab fa-twitter"></i>
             </a>
           </div>
-
+        
         </div>
-        <img class="background-logo right" alt="saito logo" src="/website/img/banner_logo.png"></img>
+        <div class="right">
+        <img class="background-logo" alt="saito logo" src="/website/img/banner_logo.png"></img>
+        </div>
       </section>
     </div>
     <div class="sectionWrapper2">
@@ -404,7 +406,7 @@
         <div class="iconWrapper">
           <img class="logoImage" alt="icon" src="/website/img/saito-logo.png"></img>
           <div class="littleIcon">
-            <a class="itemImage far fa-envelope website-newsletter-subscribe" title="Subscribe to our Newsletter"></a>
+            <a title="Subscribe to our Newsletter"><i class="itemImage far fa-envelope website-newsletter-subscribe"></i></a>
             <a href="https://org.saito.tech/blog" title="Saito Blog" target="blank">
               <i class="itemImage fas fa-rss-square"></i>
             </a>
@@ -433,7 +435,7 @@
               <a alt="developer resources" data-il8n="developers"
                 href="https://org.saito.tech/developers">Developers</a>
             </div>
-            <a href="https://cn.saito.io" title="中文版" data-il8n-from="en" data-il8n-to="zh" data-il8n-from-text="EN"
+            <a class="language-info translate-toggle" href="https://cn.saito.io" title="中文版" data-il8n-from="en" data-il8n-to="zh" data-il8n-from-text="EN"
               data-il8n-to-text="中文">中文
               <!-- <img class="icon chinese" alt="icon" src="/website/img/cn_Icon_bot.png"></img> -->
             </a>

--- a/mods/website/web/index.html
+++ b/mods/website/web/index.html
@@ -98,7 +98,7 @@
 --->
           </div>
           
-          <div class="littleIcon mobile">
+          <div class="littleIcon">
             <a class="itemImage far fa-envelope website-newsletter-subscribe" title="Subscribe to our Newsletter"></a>
             <a id="weixin-link">
               <i class="itemImage fab fa-weixin" aria-hidden="true"></i>

--- a/mods/website/web/style.css
+++ b/mods/website/web/style.css
@@ -181,7 +181,7 @@ section {
 
 .sectionWrapper1 {
   width: 100%;
-  padding: 0 4rem;
+  padding: 4rem 4rem;
   margin: 3em auto 0;
   background-image: url("/website/img/hex_background.png");
   background-repeat: no-repeat;
@@ -235,12 +235,13 @@ section {
 }
 
 .section1 .left .content {
-  width: 64.6rem;
+  max-width: 64.6rem;
+  padding-right: 1em;
 }
 .section1 .left .content, #subpage #content {
   margin: 2.5rem 0rem;
-  line-height: 24px;
-  font-size: 18px;
+  line-height: 3rem;
+  font-size: 2.25rem;
   font-weight: 400;
   color: #000000;
 }
@@ -268,7 +269,14 @@ section {
   transform-origin: center;
 }
 
-.section1 .right {
+
+.section1 .right{
+  flex:  1;
+  display: flex;
+  justify-content: flex-end;
+}
+.section1 .background-logo {
+  /* rem toggles from 8px to 12px at 1200 view screen width */
   width: 33.7rem;
   height: 38.4rem;
 }
@@ -975,6 +983,9 @@ h2, h5 {
 }
 
 @media only screen and (max-width: 1600px) {
+  html{
+    font-size: 10px;
+  }
   .section1 .left .desc {
     font-size: 5.2rem;
   }
@@ -1131,10 +1142,15 @@ h2, h5 {
   .section1 .left {
     order: 2;
   }
+
+  .section1 .right{
+    order: 1;
+    justify-content: center;
+  }
   .section1 .background-logo {
     width: 60%;
     height: 100%;
-    order: 1;
+    
   }
   .section1 .left .desc {
     flex-direction: column;
@@ -1346,6 +1362,7 @@ h2, h5 {
   #settings-dropdown .account-info #header-token-select {
     width: 17rem;
   }
+
 }
 
 .loading {
@@ -1699,34 +1716,37 @@ h2, h5 {
   position: relative;
   top: 100px;
   margin: 0 5em;
-  line-height: 60px;
+  /*line-height: 60px;*/
 }
 
 .alert span {
-  font-size: 2em;
+  font-size: 3em;
+  line-height: 3em;
 }
 
-
+/*
+This whole rule is kind of useless as it shrinks .alert from the 768-1200px range
 @media only screen and (max-width: 1200px) {
-  .alert {
+  /*.alert { Not enough space to fit header
     top: 75px;
- }
+ }*
  .alert span {
   font-size: 3em;
 }
 }
+*/
 
-
-@media only screen and (max-width: 760px) {
+@media only screen and (max-width: 768px) {
   .alert {
-    line-height: 20px;
+    /*line-height: 20px; adjusting line-height through child element*/
     padding: 1em;
     margin: 0 1em 7em;
-    top: 100px;
+    /*top: 100px; redundant*/
   }
   .alert span {
     display: block;
     font-size: 2em;
+    line-height: 1em;
   }
 
   .section1 .itemImage {


### PR DESCRIPTION
1) Fixed a bug where the newsletter icon in the footer was out of alignment
2) Made sure that the 中文 link in the footer behaves the same as in the header (using the auto-translate rather than opening a new page)
3) Hid the set of icons in the main screen because it looks weird and do you need two sets of contact icons? (However, left them in the mobile version because aesthetically pleasing)
4) Made a lot of tweaks to improve the responsive layout (only alert/section1) across different screen widths to keep things from running off screen or getting covered up.