### PR TITLE
Generalized game-playerbox and deployed in blackjack

### DIFF
--- a/lib/saito/ui/game-playerbox/game-playerbox.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.js
@@ -7,28 +7,37 @@ class GamePlayerBox {
       this.game_mod = null;
     }
 
+
+    /*
+      Test is DOM contains element ID player-info-1, if not 
+      create all the player boxes, positioned by PlayersBoxArray 
+    */
     render(app, game_mod) {
-
-      this.app = app;
       this.game_mod = game_mod;
-
-      let playerboxes = this.returnPlayersBoxArray();
-
+      
       try {
-	let playerbox_id = "player-info-1";
-        if (!document.getElementById(playerbox_id)) {
-	  for (let pnum = 0; pnum < game_mod.game.players.length; pnum++) {
-            document.body.append(app.browser.htmlToElement(GamePlayerBoxTemplate(playerboxes[pnum])));
-	  }
-        }
-      } catch (err) {}
+  	     //let playerboxes = this.returnPlayersBoxArray();
+         if (!document.getElementById("player-box-1")) { //Even a 1-player game has at #player-box-1
+	         for (let pnum = 0; pnum < game_mod.game.players.length; pnum++) {
+              let pBox = app.browser.htmlToElement(GamePlayerBoxTemplate(this._playerBox(pnum)));
+              if (document.querySelector(".main")) //If Game has a Main, put the boxes in there
+                  document.querySelector(".main").append(pBox);
+              else document.body.append(pBox);  //Otherwise, just append to body
+              this.refreshName(pnum); //Player names included in box by default
+	           }
+          }
+        } catch (err) {}
 
     }
 
     attachEvents(app, data) {
+
     }
 
 
+    /*
+
+    */
     returnPlayersBoxArray() {
 
       let player_box = [];
@@ -47,67 +56,111 @@ class GamePlayerBox {
     
       let player_box = [];
     
-      if (this.game.players.length == 2) { player_box = [3, 5]; }
-      if (this.game.players.length == 3) { player_box = [3, 4, 5]; }
-      if (this.game.players.length == 4) { player_box = [2, 3, 5, 6]; }
-      if (this.game.players.length == 5) { player_box = [2, 3, 4, 5, 6]; }
+      if (this.game_mod.game.players.length == 2) { player_box = [3, 5]; }
+      if (this.game_mod.game.players.length == 3) { player_box = [3, 4, 5]; }
+      if (this.game_mod.game.players.length == 4) { player_box = [2, 3, 5, 6]; }
+      if (this.game_mod.game.players.length == 5) { player_box = [2, 3, 4, 5, 6]; }
     
       return player_box;
   
     }
 
-
-
-    refreshCards(pnum, cards=0) {
+    /*
+    Given the game_module-based player number, determine where they sit around the table
+    */
+    _playerBox(pnum){
+      if (pnum<0) return 1;
 
       let player_box = this.returnPlayersBoxArray();
-      let player_box_num = player_box[pnum-1];
-      let divname = "#player-info-hand-" + player_box_num;
-      let boxobj = document.querySelector(divname);
-
-      let newhtml = "";
-      for (let z = 0; z < cards; z++) { newhtml += `<img class="card" src="${this.game_mod.card_img_dir}/red_back.png">`; }
-      boxobj.innerHTML = newhtml;
-
+      //Shift players in Box Array according to whose browser, so that I am always in seat 1
+      let prank = this.game_mod.game.players.indexOf(this.app.wallet.returnPublicKey());
+      let seat = pnum - prank;
+      if (seat < 0) { seat += this.game_mod.game.players.length }
+    
+      return player_box[seat];
     }
+
 
 
     refreshName(pnum, name="") {
+      let selector = "#player-box-head-"+this._playerBox(pnum);
+      let identicon = "";
 
-      let player_box = this.returnPlayersBoxArray();
-      let player_box_num = player_box[pnum-1];
-      let divname = "#player-info-name-" + player_box_num;
-      let boxobj = document.querySelector(divname);
-
-      let player_name = name;
-      if (player_name == "") {
-        player_name = this.game_mod.game.players[pnum-1];
-        player_name = this.app.keys.returnIdentifierByPublicKey(player_name, 1);
-        if (player_name.indexOf("@") > 0) {
-          player_name = player_name.substring(0, player_name.indexOf("@"));
-        }
-        if (player_name == this.game_mod.game.player[pnum-1]) {
-          player_name = player_name.substring(0, 10) + "...";
+      if (name == "") {
+        name = this.game_mod.game.players[pnum];
+        name = this.app.keys.returnIdentifierByPublicKey(name, 1);
+        identicon = this.app.keys.returnIdenticon(name);
+        if (name.indexOf("@") > 0) {
+          name = name.substring(0, name.indexOf("@"));
         }
       }
-
-      boxobj.innerHTML = player_name;
-
-    }
-
-
-    refreshStatus(pnum, status="") {
-
-      let player_box = this.returnPlayersBoxArray();
-      let player_box_num = player_box[pnum-1];
-      let divname = "#player-info-" + player_box_num;
-      let boxobj = document.querySelector(divname);
-      let player_name = this.game_mod.game.players[pnum-1];
-
-      boxobj.querySelector(".plog").innerHTML = status;
+      let html = (identicon)? `<img class="player-identicon" src="${identicon}">` : ""; 
+      html += `<div class="player-info-name">${name}</div>`;    
+      this._updateDiv(selector,html);
 
     }
 
+    _updateDiv(selector, html){
+      let div = document.querySelector(selector);
+      if (div)
+        div.innerHTML = html; 
+      else console.log(selector + " not found");
+    }
+
+    /*
+    Different games may attach classes to the graphics container to customize the graphical display
+    Card games will use hand/tinyhand
+    Other games will use ...
+    */
+    addGraphicClass(className){
+      let playerBoxes = document.querySelectorAll(".player-box-graphic");
+      for (let hand of playerBoxes){
+        hand.classList.remove(className);
+        hand.classList.add(className);
+      }
+    }
+
+    /*
+    For all the refresh elements of playerbox, we default to this player (in the 1 seat)
+    */
+
+    refreshGraphic(html, pnum=-1) {
+      this._updateDiv("#player-box-graphic-"+this._playerBox(pnum), html);
+    }
+
+
+  /*
+    Log (plog) is another section of the playerbox for status/plog information, 
+    also where we can insert menu options for player controls
+    */
+    refreshLog(html, pnum=-1) {
+      this._updateDiv("#player-box-log-"+this._playerBox(pnum), html);
+    }
+
+    /*
+    Info is a hide-able section of the playerbox, where we can display the player's score and role in this round
+    (We typically hide it to clear up space when presenting menu options through the log, see below)
+    */
+    refreshInfo(html, pnum=-1){
+      this._updateDiv("#player-box-info-"+this._playerBox(pnum), html);
+    }
+
+    hideInfo(pnum=-1){
+      let selector = "#player-box-info-"+this._playerBox(pnum);
+      try{
+      document.querySelector(selector).classList.add("hidden");
+      }catch(err){}
+    }
+
+    showInfo(pnum=-1){
+      let selector = "#player-box-info-"+this._playerBox(pnum);
+      try{
+        document.querySelector(selector).classList.remove("hidden");
+      }catch(err){
+      }
+    }
+
+    
 
 }
 

--- a/lib/saito/ui/game-playerbox/game-playerbox.template.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.template.js
@@ -1,13 +1,10 @@
 module.exports = GamePlayerBoxTemplate = (player_num) => {
   return `
-    <div class="player-info p${player_num}" id="player-info-${player_num}">
-      <div class="info" style="display: block;">
-        <div class="player-info-hand hand tinyhand" id="player-info-hand-${player_num}">
-        </div>
-        <div class="player-info-name dealerbutton bigblind" id="player-info-name-${player_num}"></div>
-        <div class="player-info-chips" id="player-info-chips-${player_num}"></div> 
-      </div>
-      <div class="plog status"></div>
+    <div class="player-box p${player_num}" id="player-box-${player_num}">
+      <div class="player-box-graphic" id="player-box-graphic-${player_num}"></div> 
+      <div class="player-box-head" id="player-box-head-${player_num}"></div>
+      <div class="player-box-info" id="player-box-info-${player_num}"></div>
+      <div class="plog ${(player_num==1)? "status":""}" id="player-box-log-${player_num}"></div>
       </div>
     </div>
   `;

--- a/mods/blackjack/blackjack.js
+++ b/mods/blackjack/blackjack.js
@@ -612,12 +612,15 @@ toggleIntro() {
       }
 
       if (mv[0] === "winner") { //copied from poker
-        let player = parseInt(mv[1]);
-        console.log("HI WINNER!");
-        let winner = this.game.state.player[player].name + " wins!";
-        this.updateStatus("Game Over: " + (player == this.game.player)? "You win!" : winner);
-        this.updateLog("Game Over: " + winner);
-        this.game.winner = this.game.players[player];
+        let winner = parseInt(mv[1]);
+        let winnerName = this.game.state.player[winner].name + " wins!";
+        this.updateLog("Game Over: " + winnerName);
+        let status = "<h2>Game Over: </h2><p>";
+        status += (winner+1 == this.game.player)? "You win!" : winnerName;
+        status += "</p>";
+        this.updateStatus(status);
+          
+        this.game.winner = this.game.players[winner];
         //this.resignGame(this.game.id); //post to leaderboard - ignore 'resign'
         return 0;
       }
@@ -778,12 +781,12 @@ toggleIntro() {
 
     if (this.browser_active == 0) { return; }
 
-    try {
+   // try {
       this.displayPlayers();
       this.displayHand();
-    } catch (err) {
-      console.log("err: " + err);
-    }
+   // } catch (err) {
+    //  console.log("err: " + err);
+   // }
 
   }
 
@@ -813,90 +816,41 @@ toggleIntro() {
 
   }
 
-  updatePlayerLog(player, msg) {
+  
 
-    let divname = "#player-info-log-" + (player);
-    let logobj = document.querySelector(divname);
-    if (logobj) {
-      logobj.innerHTML = msg;
-    }
-
-  }
-
-
-  returnPlayersBoxArray() {
-
-    let player_box = [];
-
-    if (this.game.players.length == 2) { player_box = [1, 4]; }
-    if (this.game.players.length == 3) { player_box = [1, 3, 5]; }
-    if (this.game.players.length == 4) { player_box = [1, 3, 4, 5]; }
-    if (this.game.players.length == 5) { player_box = [1, 2, 3, 5, 6]; }
-    if (this.game.players.length == 6) { player_box = [1, 2, 3, 4, 5, 6]; }
-
-    return player_box;
-
-  }
-
-  returnViewBoxArray() { //Does this.game.players.length decrement when player eliminated
-
-    let player_box = [];
-
-    if (this.game.players.length == 2) { player_box = [3, 5]; }
-    if (this.game.players.length == 3) { player_box = [3, 4, 5]; }
-    if (this.game.players.length == 4) { player_box = [2, 3, 5, 6]; }
-    if (this.game.players.length == 5) { player_box = [2, 3, 4, 5, 6]; }
-
-    return player_box;
-
-  }
-
+  
   /*
   Player should see their hand in position 1 of player_box, other players are even spaced around "poker table"
   */
   displayPlayers() {
 
     if (this.browser_active == 0) { return; }
-
-    let player_box = "";
-
-    var prank = 0;
-    if (this.game.players.includes(this.app.wallet.returnPublicKey())) {
-      player_box = this.returnPlayersBoxArray();
-      prank = this.game.players.indexOf(this.app.wallet.returnPublicKey());
-    } else {
-      document.querySelector('.status').innerHTML = "You are out of the game.<br />Feel free to hang out and chat.";
-      document.querySelector('.cardfan').classList.add('hidden');
-      player_box = this.returnViewBoxArray();
-    }
-    if (player_box.length == 0){
-      console.log("No players to display");
-      return;
-    }
-
-    for (let j = 2; j < 7; j++) { //Empty chairs are in DOM, but dynamically hidden/displayed
-      let boxobj = document.querySelector("#player-info-" + j);
-      if (!player_box.includes(j)) {
-        boxobj.style.display = "none";
-      } else {
-        boxobj.style.display = "block";
-      }
-    }
-
+    this.playerbox.render(this.app, this); 
+    this.playerbox.addGraphicClass("hand");   
+    this.playerbox.addGraphicClass("tinyhand");   
+  
     for (let i = 0; i < this.game.players.length; i++) {
-      let seat = i - prank;
-      if (seat < 0) { seat += this.game.players.length }
-
-      let player_box_num = player_box[seat];
-      let divname = "#player-info-" + player_box_num;
-      let boxobj = document.querySelector(divname);
       let newhtml = '';
       let player_hand_shown = 0;
 
       if (this.game.state.player.length > 0) {
+        //this.playerbox.refreshName(i);
+
+        newhtml = `<div class="chips">Chips: ${this.game.state.player[i].credit} ${this.game.options.crypto}</div>`;
+        if (this.game.state.dealer == (i+1)){
+          newhtml += `<div class="player-notice dealer">DEALER</div>`;  
+        }else{
+          newhtml += `<div class="player-notice">Player ${i+1}</div>`;  
+        }
+        
+        
+      
+        this.playerbox.refreshInfo(newhtml, i);
+        newhtml = "";
+        
         if (this.game.state.player[i].hand) {
             player_hand_shown = 1;
-            newhtml = `<div class="player-info-hand hand tinyhand" id="player-info-hand-${i + 1}">`;
+            //Make Image Content     
             if (this.game.state.player[i].hand.length < 2) { //One Hidden Card
                 newhtml += `<img class="card" src="${this.card_img_dir}/red_back.png">`;
             }
@@ -904,11 +858,8 @@ toggleIntro() {
               let card = this.game.deck[0].cards[this.game.state.player[i].hand[z]];
               newhtml += `<img class="card" src="${this.card_img_dir}/${card.name}">`;
             }
-       
-           newhtml += `</div>
-              <div class="player-info-name" id="player-info-name-${i + 1}">${this.game.state.player[i].name}</div>
-              <div class="player-info-chips" id="player-info-chips-${i + 1}">Chips: ${this.game.state.player[i].credit} ${this.game.options.crypto}</div> 
-           `;
+            newhtml += `</div>`;
+            this.playerbox.refreshGraphic(newhtml, i);
         }
       }
       /*
@@ -929,21 +880,7 @@ toggleIntro() {
           this.cardfan.render(this.app, this, cardfan_backs);
           this.cardfan.attachEvents(this.app, this);
       }
-
-      
-      /*
-      if (boxobj.querySelector(".plog").innerHTML == "") {
-        boxobj.querySelector(".plog").innerHTML += `<div class="player-info-log" id="player-info-log-${i + 1}"></div>`;
-      }
-      */
-      if (this.game.state.dealer == (i+1)) {
-        newhtml += `<div class="player-notice">DEALER</div>`;        
-        boxobj.classList.add("dealer");
-      }else {
-        newhtml += `<div class="player-notice">Player ${i+1}</div>`;
-        boxobj.classList.remove("dealer");
-      }
-      boxobj.querySelector(".info").innerHTML = newhtml;
+    
     }
   }
 
@@ -1195,13 +1132,18 @@ toggleIntro() {
   }
 
 
+  /*
+    This function may be less than ideal, abusing the concept of status, 
+    since it is mostly being used to update the DOM for user interface
+  */
   updateStatus(str, hide_info=0) {
-
     try {
       if (hide_info == 0) {
-        document.querySelector(".p1 > .info").style.display = "block";
+        this.playerbox.showInfo();
+        //document.querySelector(".p1 > .info").style.display = "block";
       } else {
-        document.querySelector(".p1 > .info").style.display = "none";
+        this.playerbox.hideInfo();
+        //document.querySelector(".p1 > .info").style.display = "none";
       }
 
       if (this.lock_interface == 1) { return; }

--- a/mods/blackjack/web/index.html
+++ b/mods/blackjack/web/index.html
@@ -26,39 +26,8 @@
   </head>
 
   <body>
-    <div class="shim hidden">
-      <div class="shim-notice"></div>
-    </div>
     <div class="main" id="main" style="display:all">
-      
       <div class="gameboard" id="gameboard">
-        <div class="player-info p1" id="player-info-1">
-          <div class="info"></div>
-          <div class="plog status" id=""></div>
-        </div>
-
-        <div class="player-info p2" id="player-info-2">
-          <div class="info"></div>
-          <div class="plog"></div>
-        </div>
-
-        <div class="player-info p3" id="player-info-3">
-          <div class="info"></div>
-          <div class="plog"></div>
-        </div>
-        <div class="player-info p4" id="player-info-4">
-          <div class="info"></div>
-          <div class="plog"></div>
-        </div>
-        <div class="player-info p5" id="player-info-5">
-          <div class="info"></div>
-          <div class="plog"></div>
-        </div>
-        <div class="player-info p6" id="player-info-6">
-          <div class="info"></div>
-          <div class="plog"></div>
-        </div>
-
       </div>
     </div>
     <script id="saito" type="text/javascript" src="/saito/saito.js"></script>

--- a/mods/blackjack/web/style.css
+++ b/mods/blackjack/web/style.css
@@ -39,18 +39,12 @@ body {
   padding: 10px;
 }
 
-.menu-player {
-  font-size: 1.1em;
+.dealer {
+  background-color: #0004;
+  border-top: 1px solid #efefef;
+  border-bottom: 1px solid #efefef;
 }
 
-.menu_option{
-  text-transform: uppercase;
-}
-
-.menu-table {
-  margin-top: 15px;
-  margin-bottom: 15px;
-}
 
 .hand {
   margin-left: auto;
@@ -64,38 +58,175 @@ body {
   float: none;
 }
 
-.deal .card {
-  width: 10vw;
-  max-width: 20vh;
+
+.suit {
+  font-size: larger;
 }
 
-.deal {
-  margin: 0 auto;
-  position: absolute;
-  top: 30vh;
-  left: 50vw;
-  transform: translateX(-50%);
-  width: unset;
+.htmlCard {
+  margin: 5px 3px;
+  display: inline-block;
+  background: #fffD;
+  padding: 4px 3px;
+  border-radius: 6px;
 }
 
-.pot {
-  border: 1px solid #555;
-  position: absolute;
-  top: 54vh;
-  left: 50vw;
-  transform: translateX(-50%);
-  background-color: whitesmoke;
-  padding: 3px 16px 0px 16px;
-  border-radius: 15px;
+.hud {
+  display: none;
+}
+
+.status-message {
+  background-color: transparent;
+  box-shadow: none;
+  width: 100%;
+}
+.status ul li:hover {
+  background: #ccc3;
+}
+
+.player-info-log {
+  font-size: 2vh;
   text-align: center;
-  text-valign: middle;
-  font-size: 2.6em;
-  font-weight: bold;
-  color: #555;
-  line-height: 1.1em;
+  border: 1px solid #aaaa;
 }
 
-.player-info {
+.menu-player {
+  font-size: 2vh;
+  font-weight: bolder;
+}
+
+
+.menu_option{
+  text-transform: uppercase;
+}
+
+.menu-table {
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
+
+
+
+.hidden {
+  display: none;
+}
+
+
+
+
+@media screen and (orientation: landscape) and (max-height: 450px) {
+
+  .player-info {
+    padding: 5px;
+  }
+
+  .deal .card {
+    width: 8vw;
+  }
+
+  .player-info.p1 {
+    height: 40vh;
+    width: 30vw;
+  }
+
+  .status ul li { 
+    line-height: 2.5em;
+    font-size: 1em;
+    width: 100%;
+  }
+
+  .cardfan {
+    left: 15vw;
+    top: 60vh;
+  }
+
+  .cardfan .card {
+    width: 14vw;
+  }
+
+
+}
+
+
+@media screen and (orientation: portrait) and (max-width: 450px) {
+
+  .player-info {
+    padding: 5px;
+  }
+
+
+  .player-info.p1 {
+    height: 25vh;
+    width: 60vw;
+  }
+
+  .player-info-hand .card {
+    width: 16vw;
+  }
+
+  .status ul li { 
+    line-height: 2.5em;
+    font-size: 1em;
+    width: 100%;
+  }
+
+ 
+
+  .cardfan {
+    left: 25vw;
+    top: 46vh;
+  }
+
+  .cardfan .card {
+    width: 35vw;
+  }
+
+  .p4 .hand, .p3 .hand, .p2 .hand {
+    right: 15vw;
+    top: 10vh;
+  }
+
+}
+
+
+
+
+@media screen and (orientation: portrait) and (max-width: 450px) {
+
+  .player-info.p2 {
+    display: none;
+    visibility: hidden;
+  }
+  .player-info.p3 {
+    display: none;
+    visibility: hidden;
+  }
+  .player-info.p4 {
+    display: none;
+    visibility: hidden;
+  }
+  .player-info.p5 {
+    display: none;
+    visibility: hidden;
+  }
+  .player-info.p6 {
+    display: none;
+    visibility: hidden;
+  }
+
+
+  .cardfan {
+    top: 36vh;
+  }
+
+}
+
+
+/*
+  This CSS is duplicated in game.css
+*/
+
+/*.player-info {
   width: min(25vh,25vw);
   height: 20vh;
   background-color: #4448;
@@ -109,10 +240,6 @@ body {
 }
 .player-info .status {
   font-size: 1.25em;
-}
-
-.status-info {
-  padding: 10px 0;
 }
 
 
@@ -156,6 +283,9 @@ body {
   width: 12vh;
   position: absolute;
 }
+*/
+
+/*
 
 .cardfan {
   position: absolute;
@@ -168,9 +298,9 @@ body {
   width: 17.5vh;
 }
 
-/* .card:nth-child(1n+2) {
+.card:nth-child(1n+2) {
   left: -130px;
-} */
+} 
 
 .cardfan>.card:nth-child(1) {
   transform: rotate(-20deg);
@@ -220,246 +350,4 @@ body {
 .hand>.card:nth-child(5) {
   transform: rotate(20deg);
   left: 8vh;
-}
-
-.suit {
-  font-size: larger;
-}
-
-.htmlCard {
-  margin: 5px 3px;
-  display: inline-block;
-  background: #fffD;
-  padding: 4px 3px;
-  border-radius: 6px;
-}
-
-.hud {
-  display: none;
-}
-
-.status-message {
-  background-color: transparent;
-  box-shadow: none;
-  width: 100%;
-}
-.status ul li:hover {
-  background: #ccc3;
-}
-
-.player-info-log {
-  font-size: 2vh;
-  text-align: center;
-  border: 1px solid #aaaa;
-}
-
-.menu-player {
-  font-size: 2vh;
-  font-weight: bolder;
-}
-
-.smallblind::before {
-  content: "◉";
-  margin-right: 0.5em;
-  color: aqua;
-  -webkit-text-stroke: 1px #444;
-}
-
-.bigblind::before {
-  content: "◉";
-  margin-right: 0.5em;
-  color: yellow;
-  -webkit-text-stroke: 1px #444;
-}
-
-.dealerbutton::before {
-  content: "⬤";
-  margin-right: 0.5em;
-  color: #fff;;
-  -webkit-text-stroke: 1px #444;
-}
-
-.shim {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  background: #222b;
-  z-index: 101;
-  cursor: pointer;
-}
-
-.shim-notice {
-  background: #222b;
-  position: absolute;
-  top: 50vh;
-  transform: translate(-50%, -50%);
-  color: #fff;
-  left: 50vw;
-  padding: 5vh;
-}
-
-.hidden {
-  display: none;
-}
-
-.shim-notice .card {
-  width: 5vw;
-  max-width: 8vh;
-  min-width: 60px;
-}
-
-
-
-
-
-
-
-@media screen and (orientation: landscape) and (max-height: 450px) {
-
-  .player-info {
-    padding: 5px;
-  }
-
-  .deal .card {
-    width: 8vw;
-  }
-  .pot {
-    top: 50vh;
-    font-size: 1.4em;
-  }
-
-  .player-info.p1 {
-    height: 40vh;
-    width: 30vw;
-  }
-
-  .status ul li { 
-    line-height: 2.5em;
-    font-size: 1em;
-    width: 100%;
-  }
-
-  .cardfan {
-    left: 15vw;
-    top: 60vh;
-  }
-
-  .cardfan .card {
-    width: 14vw;
-  }
-
-  .shim-notice {
-    max-width: 100vw;
-    width: 80vw;
-    overflow-y: scroll;
-  }
-
-}
-
-
-@media screen and (orientation: portrait) and (max-width: 450px) {
-
-  .player-info {
-    padding: 5px;
-  }
-
-  .pot {
-    top: 50vh;
-    font-size: 1.4em;
-  }
-
-  .player-info.p1 {
-    height: 25vh;
-    width: 60vw;
-  }
-
-  .player-info-hand .card {
-    width: 16vw;
-  }
-
-  .status ul li { 
-    line-height: 2.5em;
-    font-size: 1em;
-    width: 100%;
-  }
-
-  .deal {
-    margin: 0 auto;
-    position: absolute;
-    top: 30vh;
-    left: 45vw;
-    transform: inherit;
-    width: 90vw;
-    margin-left: 5vw;
-    margin-right: auto;
-    transform: translate(-50%);
-  }
-
-  .deal .card {
-    width: 18vw;
-  }
-
-  .cardfan {
-    left: 25vw;
-    top: 46vh;
-  }
-
-  .cardfan .card {
-    width: 35vw;
-  }
-
-  .p4 .hand, .p3 .hand, .p2 .hand {
-    right: 15vw;
-    top: 10vh;
-  }
-
-  .shim-notice {
-    max-width: 100vw;
-    width: 80vw;
-    overflow-y: scroll;
-  }
-
-}
-
-
-
-
-@media screen and (orientation: portrait) and (max-width: 450px) {
-
-  .player-info.p2 {
-    display: none;
-    visibility: hidden;
-  }
-  .player-info.p3 {
-    display: none;
-    visibility: hidden;
-  }
-  .player-info.p4 {
-    display: none;
-    visibility: hidden;
-  }
-  .player-info.p5 {
-    display: none;
-    visibility: hidden;
-  }
-  .player-info.p6 {
-    display: none;
-    visibility: hidden;
-  }
-
-  .deal {
-    top: 10vh;
-  }
-
-  .cardfan {
-    top: 36vh;
-  }
-
-}
-
-
-
-
-
+} */

--- a/web/saito/lib/templates/game.css
+++ b/web/saito/lib/templates/game.css
@@ -115,7 +115,7 @@ body {
   text-align: center;
   padding: 0;
   margin: 0;
-  width: 120px;
+  width: 125px;
   max-width: 150px;
   border-bottom: none;
   height: 40px;
@@ -139,6 +139,7 @@ body {
   box-shadow: 2px 2px 5px 0px rgba(0,0,0,0.75);
   height: 50px;
   line-height: 50px;
+  width: 125px;
 }
 .game-menu-sub-options {
   display:none;
@@ -577,7 +578,7 @@ ul li a {
 }
 
 
-.player-info {
+.player-box {
   width: 25vh;
   height: 20vh;
   background-color: #4448;
@@ -586,23 +587,38 @@ ul li a {
   position: absolute;
 }
 
-.player-info.p1 {
+.player-box.p1 {
   height: 30vh;
 }
-.player-info .status {
+
+.player-box .plog {
+  margin: 0.5em;
   font-size: 1.25em;
 }
 
+.player-box-head{
+   width: 100%;
+   display: inline-flex;
+   align-items: center;
+}
+
+.player-box-head .player-identicon{
+    width: 3vh;
+    box-shadow: 0px 3px 6px #00000029;
+}
+
 .player-info-name {
-  font-size: 3vh;
   font-weight: bold;
-  text-align: center;
+  font-size: 3vh;
+  padding-left: 0.5em;
+  text-align: left;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
-.player-info-chips {
+
+.player-box-info .chips {
   padding: 0.5em;
   text-align: center;
   font-size: 3vh;
@@ -623,7 +639,7 @@ ul li a {
   top: 2vh;
 }
 
-.player-info-hand .card {
+.player-box-graphic .card {
   width: 12vh;
   position: absolute;
 }
@@ -996,6 +1012,7 @@ input#game_board_sizer {
   .game-menu ul li {
     max-width: 75px;
     width: 75px;
+    font-size: 0.9rem;
   }
 
 }
@@ -1012,8 +1029,9 @@ input#game_board_sizer {
 
   }
   .game-menu ul li {
-    max-width: 85px;
-    width: 85px;
+    max-width: 100px;
+    width: 100px;
+    font-size: 1rem;
   }
 
 }
@@ -1031,6 +1049,7 @@ input#game_board_sizer {
   .game-menu ul li {
     max-width: 85px;
     width: 85px;
+    font-size: 1rem;
   }
 
 }


### PR DESCRIPTION
Think I finally fixed the bug where the wrong player was being reported as the winner. 

This push is mostly a fix to the GamePlayerBox module (and its associated game.css)

So GamePlayerBox contains four elements: head (which displays player's identicon and name), a graphical element (which is the hand/tinyhand here), an info element, and a log element. Other than head, the other three elements are customizable, accepting whatever html the developer wants to put in. 

I will need to further change the code to facilitate positioning the boxes dynamically around a game board rather than poker table positions, but as you can see, I've faithfully recreated blackjack's display using the new module. 

![image](https://user-images.githubusercontent.com/70703104/137595775-2b439ad6-7e90-4146-9aa7-3125b935903e.png)
