### PR TITLE
devops: disable the rust demo code so it doesn't accidentally get deployed

### DIFF
--- a/lib/saito/networkapi.js
+++ b/lib/saito/networkapi.js
@@ -77,8 +77,10 @@ class NetworkAPI {
    * other parts of the system may not be ready yet.
    */
   initialize() {
-    this.wsConnectToRustPeer();
-    this.getDemoBlockFromRust();
+    // Demo of how to connect to Rust here:
+    // Disabling these, they are not meant to be shipped.
+    // this.wsConnectToRustPeer();
+    // this.getDemoBlockFromRust();
   }
 
   /**


### PR DESCRIPTION
It wouldn't hurt anything, but it just isn't needed...