### PR TITLE
integrated gameplayerbox into wuziqi

### DIFF
--- a/lib/saito/browser.js
+++ b/lib/saito/browser.js
@@ -570,6 +570,8 @@ class Browser {
           // set the element's new position:
           element_to_move.style.left = (element_start_left + adjustmentX) + "px";
           element_to_move.style.top = (element_start_top + adjustmentY) + "px";
+          element_to_move.style.bottom = "unset";
+          element_to_move.style.right = "unset";
 
         };
       };
@@ -625,7 +627,8 @@ class Browser {
           // set the element's new position:
           element_to_move.style.left = element_start_left + adjustmentX + "px";
           element_to_move.style.top = element_start_top + adjustmentY + "px";
-
+          element_to_move.style.bottom = "unset";
+          element_to_move.style.right = "unset";
         };
       };
 

--- a/lib/saito/ui/game-playerbox/game-playerbox.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.js
@@ -1,3 +1,17 @@
+/*
+  A Class to Make Playerboxes for displaying information about all the players in the game
+  Basic template: 
+    --- a Head for the Player's identicon and name
+    --- a Div for Information (formatted to the players specification)
+    --- a Div for Player log (to include additional information), 
+          this defaults to status for the player and is used by some games for interactive controls
+    --- a Div for graphical elements, such a dealt hand of cards
+
+    Use render to create the playerboxes
+    Use attachEvents to make them movable
+
+*/
+
 const GamePlayerBoxTemplate = require('./game-playerbox.template');
 
 class GamePlayerBox {
@@ -17,9 +31,11 @@ class GamePlayerBox {
       
       try {
   	     //let playerboxes = this.returnPlayersBoxArray();
-         if (!document.getElementById("player-box-1")) { //Even a 1-player game has at #player-box-1
+         
 	         for (let pnum = 0; pnum < game_mod.game.players.length; pnum++) {
-              let pBox = app.browser.htmlToElement(GamePlayerBoxTemplate(this._playerBox(pnum)));
+            let player = this._playerBox(pnum);
+            if (!document.getElementById("player-box-"+player)) { //Even a 1-player game has at #player-box-1
+              let pBox = app.browser.htmlToElement(GamePlayerBoxTemplate(player));
               if (document.querySelector(".main")) //If Game has a Main, put the boxes in there
                   document.querySelector(".main").append(pBox);
               else document.body.append(pBox);  //Otherwise, just append to body
@@ -30,10 +46,30 @@ class GamePlayerBox {
 
     }
 
-    attachEvents(app, data) {
-
+    attachEvents(app, data=null) {
+      try{
+           for (let pnum = 0; pnum < this.game_mod.game.players.length; pnum++) {
+            let player = this._playerBox(pnum);
+            app.browser.makeDraggable("player-box-"+player,"player-box-head-"+player);
+            document.querySelector("#player-box-head-"+player).style.cursor="grab";
+          }
+      }catch(err){console.log(err);}
     }
 
+
+  /*
+    Given the game_module-based player number, determine where they sit around the table
+    */
+    _playerBox(pnum){
+      if (pnum<0) return 1;
+      let player_box = this.returnPlayersBoxArray();
+      //Shift players in Box Array according to whose browser, so that I am always in seat 1
+      let prank = this.game_mod.game.players.indexOf(this.app.wallet.returnPublicKey());
+      let seat = pnum - prank;
+      
+      if (seat < 0) { seat += this.game_mod.game.players.length }
+      return player_box[seat];
+    }
 
     /*
 
@@ -66,20 +102,32 @@ class GamePlayerBox {
     }
 
     /*
-    Given the game_module-based player number, determine where they sit around the table
+    Classes p1-p6 fix the player boxes around the screen like a card table, 
+    so you can provide a class-name stub to generate x1, x2, ... classes or 
+    use a universal class name for all the boxes to customize the css 
     */
-    _playerBox(pnum){
-      if (pnum<0) return 1;
-
-      let player_box = this.returnPlayersBoxArray();
-      //Shift players in Box Array according to whose browser, so that I am always in seat 1
-      let prank = this.game_mod.game.players.indexOf(this.app.wallet.returnPublicKey());
-      let seat = pnum - prank;
-      if (seat < 0) { seat += this.game_mod.game.players.length }
-    
-      return player_box[seat];
+    addClassAll(className, isStub = true){
+      if (isStub){
+        for (let i = 1; i <= 6; i++){
+          let box = document.querySelector(`#player-box-${i}`);
+          if (box) box.classList.add(`${className}${i}`);
+        }
+      }else{
+        let boxes = document.querySelectorAll(".player_box");
+        for (let box of boxes){
+          box.classList.add(className);
+        }
+      }
     }
 
+    addClass(className, player = -1){
+      let selector = "#player-box-"+this._playerBox(player);
+      let box = document.querySelector(selector);
+      if (box)
+        box.classList.add(className);
+    }
+
+  
 
 
     refreshName(pnum, name="") {
@@ -88,7 +136,7 @@ class GamePlayerBox {
 
       if (name == "") {
         name = this.game_mod.game.players[pnum];
-        name = this.app.keys.returnIdentifierByPublicKey(name, 1);
+        name = this.app.keys.returnIdentifierByPublicKey(name, true);
         identicon = this.app.keys.returnIdenticon(name);
         if (name.indexOf("@") > 0) {
           name = name.substring(0, name.indexOf("@"));
@@ -97,7 +145,6 @@ class GamePlayerBox {
       let html = (identicon)? `<img class="player-identicon" src="${identicon}">` : ""; 
       html += `<div class="player-info-name">${name}</div>`;    
       this._updateDiv(selector,html);
-
     }
 
     _updateDiv(selector, html){

--- a/lib/saito/ui/game-playerbox/game-playerbox.template.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.template.js
@@ -1,6 +1,6 @@
 module.exports = GamePlayerBoxTemplate = (player_num) => {
   return `
-    <div class="player-box p${player_num}" id="player-box-${player_num}">
+    <div class="player-box" id="player-box-${player_num}">
       <div class="player-box-graphic" id="player-box-graphic-${player_num}"></div> 
       <div class="player-box-head" id="player-box-head-${player_num}"></div>
       <div class="player-box-info" id="player-box-info-${player_num}"></div>

--- a/mods/blackjack/blackjack.js
+++ b/mods/blackjack/blackjack.js
@@ -192,6 +192,12 @@ toggleIntro() {
     this.log.render(app, this);
     this.log.attachEvents(app, this);
 
+    this.playerbox.render(app, this);
+    //this.playerbox.attachEvents(app.this);
+    this.playerbox.addClassAll("p",true);
+    this.playerbox.addGraphicClass("hand");   
+    this.playerbox.addGraphicClass("tinyhand");   
+  
   }
 
 
@@ -825,16 +831,13 @@ toggleIntro() {
   displayPlayers() {
 
     if (this.browser_active == 0) { return; }
-    this.playerbox.render(this.app, this); 
-    this.playerbox.addGraphicClass("hand");   
-    this.playerbox.addGraphicClass("tinyhand");   
   
     for (let i = 0; i < this.game.players.length; i++) {
       let newhtml = '';
       let player_hand_shown = 0;
 
       if (this.game.state.player.length > 0) {
-        //this.playerbox.refreshName(i);
+        this.playerbox.refreshName(i);
 
         newhtml = `<div class="chips">Chips: ${this.game.state.player[i].credit} ${this.game.options.crypto}</div>`;
         if (this.game.state.dealer == (i+1)){

--- a/mods/wuziqi/web/index.html
+++ b/mods/wuziqi/web/index.html
@@ -30,20 +30,8 @@
 </head>
 
 <body>
-    <div class="inner">
+    <div class="inner main">
         <div class="board"></div>
-
-        <div class="player-box me" id="player-info-1">
-          <div class="info"></div>
-          <div class="plog"></div>
-          <div class="status" id="status"></div>
-        </div>
-
-        <div class="player-box notme" id="player-info-2">
-          <div class="info"></div>
-          <div class="plog"></div>
-        </div>
-
     </div>
     <script id="saito" type="text/javascript" src="/saito/saito.js"></script>
 </body>

--- a/mods/wuziqi/web/style.css
+++ b/mods/wuziqi/web/style.css
@@ -7,6 +7,10 @@
     background-size: cover;
 }
 
+.main{
+    margin-top: unset;
+    padding: unset;
+}
 /*
     Format the help overlay
 */
@@ -38,14 +42,7 @@
 Board is a grid of wooden squares
 */
 .board > div {
-    /*background-image: url("img/woodtile.png");
-    background-size: contain;
-    background-repeat: no-repeat;
-    background-position: center center;*/
-    /*background-image: url("img/004-polished-wood.png");
-    border: 1px solid black;
-    margin:  0 1px 1px 0;*/   
-    position: relative;
+     position: relative;
 }
 
 .board > div::after {
@@ -84,30 +81,6 @@ Board is a grid of wooden squares
 .board > div.bottom.right::after {
     border: 0px solid black;
 }
-
-/*
-    Pseudo-element shifted box border to simulate Go board lines
-
-.board > div::after{
-    content: "";
-    position: relative;
-    z-index: 0;
-    top:  -50%;
-    left: -50%;
-    border: 2px solid black;
-    width: 100%;
-    height: 100%;
-    display: block;
-}
-
-.board > .left::after{
-    display:  none;
-}
-
-.board > .bottom::after{
-    display: none;   
-}
-*/
 
 
 
@@ -172,7 +145,7 @@ Board is a grid of wooden squares
 
 
 .player-box {
-  width: 15em;
+  width: 12em;
   min-height: 10em;
   background-color: #0004;
   color: #fff;
@@ -183,10 +156,12 @@ Board is a grid of wooden squares
   font-size: 1.2em;
   text-align: center;
   box-sizing: content-box;
+  padding: 0px;
+  height: unset;
 }
 
 
-.player-box .info{
+.player-box-head{
     background: #AAA;
     box-shadow: 0px 3px 6px #00000029;
     border-bottom: 1px solid #FFFFFF;
@@ -201,27 +176,18 @@ Board is a grid of wooden squares
     
 }
 
-.player-box .info .player-name{
-    padding-left: 8px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-.player-box .identicon{
-    width: 1.5em;
-    box-shadow: 0px 3px 6px #00000029;
-}
-
-.player-box .plog{
-    margin: 0.5em;
-}
-
-.player-box .status{
-    margin: 0.5em;
+/*
+Make name a little smaller than default
+*/
+.player-box-head .player-info-name{
+    font-size: 1.5em;
 }
 
 .player-box .piece{
     width: 2em;
+    margin: 0.25em;
 }
+
 .playertitle {
     text-transform: capitalize;
 }
@@ -237,13 +203,15 @@ Board is a grid of wooden squares
 /*
     Size square board relative to the narrower screen dimension
 */
+
+
 @media (orientation: landscape) {
     .board {
-        width: 80vh;
-        height: 80vh;
+        width: 90vh;
+        height: 90vh;
     }
     .inner{
-        padding: 10vh;
+        padding: 5vh;
     }
     .player-box{
         top: 40vh;  /*Center in screen:  50vh - 1/2 height */
@@ -252,11 +220,11 @@ Board is a grid of wooden squares
     }
 
     .player-box.me{
-        left: max(5px, calc(12vw - 5em));
+        left: max(5px, calc(12vw - 7em));
     }
 
     .player-box.notme{
-        right: max(5px, calc(12vw - 5em));
+        right: max(5px, calc(12vw - 7em));
     }
 
 
@@ -264,47 +232,67 @@ Board is a grid of wooden squares
 
 @media (orientation: portrait) {
     .board {
-        width: 80vw;
-        height: 80vw;
-   
+        width: 90vw;
+        height: 90vw;
+        margin-top: max(5vw,5vh);
     }
 
     .inner{
-        padding: 7vw;
+        padding: 5vw;
+        padding-top: 0px;
     }
 
     .player-box{
-        top: calc(82vw + 7vh);
+        top: calc(65vw + 26vh);
         max-width: 35vw;
     }
 
     .player-box.me{
-        left: calc(30vw - 5em);
+        left: calc(30vw - 6em);
     }
 
     .player-box.notme{
-        right: calc(30vw - 5em);
+        right: calc(30vw - 6em);
     }
 }
 
-@media (max-aspect-ratio:  8/7) and (min-aspect-ratio: 1/1) {
-    .inner{
-        padding: 7vh;
+
+/*
+    Intermediate (roughly square screen size, technically landscape, but keep portrait layout)
+*/
+@media (max-aspect-ratio:  8/7) and (min-aspect-ratio: 7/8) {
+    .board{
+        margin-top: 0px;
+        width: 80vh;
+        height: 80vh;
     }
+    .inner{
+        padding: 5vh;
+        padding-top: 45px;
+     }
 
     .player-box{
-        top: calc(100vh - 6em);
-        max-width: 35vw;
+        top: unset;
+        bottom: 0px;
+        max-width: 40vw;
     }
 
+    .player-box-info{
+        display: inline-flex;
+        align-items: center;
+        margin: 3px;
+    }
     .player-box.me{
-        left: calc(30vw - 5em);
+        left: calc(30vw - 5.5em);
     }
 
     .player-box.notme{
-        right: calc(30vw - 5em);
+        right: calc(30vw - 5.5em);
     }
 }
+
+
+
 
 
 /*
@@ -328,6 +316,7 @@ Board is a grid of wooden squares
     .board {
         width: 95vw;
         height: 95vw;
+        margin-top: max(5vw,5vh);
     }
      .inner{
         padding: 2.5vw;
@@ -335,7 +324,7 @@ Board is a grid of wooden squares
     }
 
     .player-box{
-        top: calc(100vw + 1vh + 45px);
+        top: calc(95vw + 15vh);
         max-width: 38vw;
     }
     

--- a/mods/wuziqi/wuziqi.js
+++ b/mods/wuziqi/wuziqi.js
@@ -1,6 +1,5 @@
 const { timingSafeEqual } = require('crypto');
 const saito = require('../../lib/saito/saito');
-const dragElement = require('../../lib/helpers/drag_element');
 const GameTemplate = require('../../lib/templates/gametemplate');
 const { update } = require('../../lib/templates/lib/game-hammer-mobile/game-hammer-mobile');
 
@@ -17,7 +16,7 @@ class Wuziqi extends GameTemplate {
         this.description = "五子棋 aka Gokomu and Gobang! is a simple game where two players alternately place black and white tiles on a go board attempting to place 5 of them in adjacent positions."
         this.categories = "Boardgame Strategy";
         this.type = "Boardgame";
-        this.status = "Alpha";
+        this.status = "Beta";
 
         this.minPlayers = 2;
         this.maxPlayers = 2;
@@ -163,6 +162,13 @@ class Wuziqi extends GameTemplate {
             this.generateBoard(this.game.size);
         }
 
+
+        //Player Boxes
+        this.playerbox.render(this.app,this);
+        this.playerbox.addClass("me",this.game.player-1);
+        this.playerbox.addClass("notme",this.game.player);
+        this.playerbox.attachEvents(this.app);
+
         // Render board and set up values.
         try {
             // Check if anyone has played yet (black goes first)
@@ -259,49 +265,34 @@ class Wuziqi extends GameTemplate {
         but data structures for player properties are typically 0-indexed arrays
     */
     updateScore() {
-           /*
-            Make player box
-        */
-        let boxobj;
-        let status = document.querySelector(".status").innerHTML;
+        let roundsToWin = Math.ceil(this.game.options.best_of/2);
         for (let i = 0; i<this.game.players.length; i++){
-            let name = this.app.keys.returnIdentifierByPublicKey(this.game.players[i], 1)
-            let identicon = this.app.keys.returnIdenticon(name);
-            if (name.indexOf("@") > 0) {
-                name = name.substring(0, name.indexOf("@"));
-            }
-            if (name === this.game.players[i]) {
-               name = this.game.players[i].substring(0, 10) + "...";
-            }    
-            console.log(i,this.game.player);
-            boxobj = (this.game.player == (i+1)) ? document.querySelector(".player-box.me") : document.querySelector(".player-box.notme");
-            let info = boxobj.querySelector(".info");
-            let score = boxobj.querySelector(".plog");
+            //this.playerbox.refreshName(i);
             let scoreHTML = `<div>Score: </div>`;
-            info.innerHTML = `<img class="identicon" src="${identicon}">
-                                <div class="player-name">${name}</div>
-                                `;
-            
-            
             for (let j = 0; j < this.game.score[i]; j++) {
                 scoreHTML += `<img class="piece" src="img/${this.game.sides[i]}piece.png">`;
             }
-            for (let j = 0; j < (this.game.options.best_of - this.game.score[i]); j++) {
+            for (let j = 0; j < (roundsToWin - this.game.score[i]); j++) {
                 scoreHTML += `<img class="piece opaque30" src="img/${this.game.sides[i]}piece.png">`;
             }
-            score.innerHTML = scoreHTML; //${this.game.score[i]} (out of ${this.game.options.best_of})`;
-            try {
-                dragElement(boxobj);
-            } catch (err) {
-                console.log("Drag error",err);
-            }
+            this.playerbox.refreshInfo(scoreHTML,i);                        
         }
+    }
 
+    updateStatus(str) {
+    
+      if (this.lock_interface == 1) { return; }
 
-      //  for (let i = 0; i < 2 /*this.game.players.length==2*/; i++){
-      //      document.querySelector(`.score${i+1}`).innerHTML = `${((i+1)==this.game.player)? "*" : ""}${this.game.sides[i]}: ${this.game.score[i]}`;
-      //  }
-      //  document.querySelector(".best_of").innerHTML = "Best of " + this.game.options.best_of;
+      this.game.status = str;
+
+      if (this.browser_active == 1) {
+        let status_obj = document.querySelector(".status");
+        if (this.game.players.includes(this.app.wallet.returnPublicKey())) {
+          status_obj.innerHTML = str;
+        }
+      }
+    } catch (err) { 
+      console.log("ERR: " + err);
     }
 
 

--- a/web/saito/lib/templates/game.css
+++ b/web/saito/lib/templates/game.css
@@ -583,7 +583,8 @@ ul li a {
   height: 20vh;
   background-color: #4448;
   color: #fff;
-  padding: 1em;
+  font-size: 1.25em;
+  padding: 0.5em;
   position: absolute;
 }
 
@@ -593,13 +594,13 @@ ul li a {
 
 .player-box .plog {
   margin: 0.5em;
-  font-size: 1.25em;
 }
 
 .player-box-head{
    width: 100%;
    display: inline-flex;
    align-items: center;
+   cursor: pointer;
 }
 
 .player-box-head .player-identicon{
@@ -617,6 +618,9 @@ ul li a {
   text-overflow: ellipsis;
 }
 
+.player-box-info{
+  margin: 0.5em;
+}
 
 .player-box-info .chips {
   padding: 0.5em;
@@ -1010,8 +1014,8 @@ input#game_board_sizer {
   }
 
   .game-menu ul li {
-    max-width: 75px;
-    width: 75px;
+    max-width: 85px;
+    width: 85px;
     font-size: 0.9rem;
   }
 
@@ -1047,8 +1051,8 @@ input#game_board_sizer {
     grid-template-rows: repeat(auto-fit, 14vw);
   }
   .game-menu ul li {
-    max-width: 85px;
-    width: 85px;
+    max-width: 115px;
+    width: 115px;
     font-size: 1rem;
   }
 
@@ -1069,7 +1073,7 @@ input#game_board_sizer {
 
   .game-menu ul li {
     height; 30px;
-    width: 85px;
+    width: 115px;
     line-height: 30px;
   }
 


### PR DESCRIPTION
Further improvements of Game-Player-Box as illustrated by full integration into Wuziqi.
![image](https://user-images.githubusercontent.com/70703104/137963558-56ae3b8a-f18a-4386-a676-2ca9354a62b2.png)


Game-Player-Box still works flawlessly with Blackjack because added I functions to add classes (p1-p6 for poker positioning or me/notme for automatic positioning around a gameboard). me/notme are only in wuziqi/styles.css but may want to migrate them to game.css if other games are similarly arranged.

Had to change makeDraggable() in lib/saito/browser.js to override my weird bottom/right positioning of playerboxes and maintain moveability.

Made another pass at wuziqi's css to optimize the default sizing of board and positioning of playerboxes. I'm finally happy with it under a variety of screen dimensions. For Best X of Y games, I thought having Y grayed out tiles was confusing and changed it to X, i.e. fill in all your tiles and you win the match. Finally, I think we can bump Wuziqi up to beta, so I changed that prop.

