### PR TITLE
Words

### DIFF
--- a/mods/wordblocks/web/style.css
+++ b/mods/wordblocks/web/style.css
@@ -761,16 +761,38 @@ thead,  tfoot{
   text-shadow: 2px 2px black;
   text-align: center;
 }
-.slot .tile.ui-sortable-handle{
-  background-color: #32CD3279
-}
+
+/* Highlight selected tile in rack*/
 .tiles .tile.highlighttile{
   color: limegreen;
   border-color: limegreen;
 }
 
+/* Highlight temporary tiles on board*/
+.slot .tile.tempplacement{
+  background-color: #32CD3279;
+  color: black;
+}
+
+/* Highlight selected tile on board*/
 .slot .tile.highlighttile{
   background-color: limegreen;
+  color: black;
+}
+
+#helper{
+  position: fixed;
+  transition: transform 0.13s;
+  pointer-events: none;
+  width: 54px;
+  height: 54px;
+  background-color: limegreen;
+  font-size: 2rem;
+  text-align: center;
+  padding-top: 6px;
+  border-radius: 3px;
+  z-index: 50;
+  cursor: grabbing;
 }
 
 #deletectrl i{

--- a/mods/wordblocks/web/style.css
+++ b/mods/wordblocks/web/style.css
@@ -346,11 +346,17 @@ thead,  tfoot{
   display: block;
 }
 
+.player .player-identicon{
+    width: 80%;
+    box-shadow: 0px 3px 6px #00000029;
+}
+
 .player {
-  margin: 3px 0 12px;
+  margin: 0.125em 0 0.75em;
   white-space: nowrap;
   display: grid;
-  grid-template-columns: 90% 10%;
+  grid-template-columns: 7% 82% 10%;
+  height: 1.5em;
 }
 
 .player_name {
@@ -362,7 +368,7 @@ thead,  tfoot{
 }
 
 .player span {
-  line-height: 20px;
+  line-height: 1.5em;
 }
 
 .player_score {
@@ -540,10 +546,6 @@ thead,  tfoot{
   max-width: 95vw;
 }
 **/
-
-.player span {
-  line-height: 40px;
-}
 
 
 .rack {

--- a/mods/wordblocks/web/style.css
+++ b/mods/wordblocks/web/style.css
@@ -730,6 +730,7 @@ thead,  tfoot{
     display: inline-block;
     width: auto;
     float: left;
+    position: relative;
   }
   .tiles div.tile {
     display: inline-block;
@@ -750,6 +751,37 @@ thead,  tfoot{
   }
 }
 
+.hidden{
+  display: none;
+}
+
+.tile-placement-controls .playable{
+  font-size: 1.5em;
+  color: white;
+  text-shadow: 2px 2px black;
+  text-align: center;
+}
+.slot .tile.ui-sortable-handle{
+  background-color: #32CD3279
+}
+.tiles .tile.highlighttile{
+  color: limegreen;
+  border-color: limegreen;
+}
+
+.slot .tile.highlighttile{
+  background-color: limegreen;
+}
+
+#deletectrl i{
+  margin: 0px 1em;
+}
+
+.tiles .tile.todelete{
+  position: relative;
+  bottom: 10px;
+  background-color: #940404;
+}
 
 #promptval{
   text-transform: uppercase;

--- a/mods/wordblocks/wordblocks.js
+++ b/mods/wordblocks/wordblocks.js
@@ -519,7 +519,7 @@ class Wordblocks extends GameTemplate {
     // attach events
     //
     if (this.game.target == this.game.player) {
-      this.addEventsToBoard();
+      this.enableEvents(); //addEventsToBoard
     }
 
     try {
@@ -529,13 +529,14 @@ class Wordblocks extends GameTemplate {
           $('#tiles')[0].appendChild($('#tiles')[0].childNodes[Math.random() * i | 0]);
         }
       });
-      $('#tiles').sortable();
+      
+//Permanently make tiles sortable>>>>>>
+      $('#tiles').sortable({axis:"x",tolerance:"pointer",containment:"parent"});
       $('#tiles').disableSelection();
       $(window).resize(function () {
         resizeBoard();
       });
-
-      var element = document.getElementById('gameboard');
+      
   
       $('#game_status').on('click', () => {
         $('.log').hide();
@@ -628,10 +629,21 @@ class Wordblocks extends GameTemplate {
     for (let i = 0; i < players; i++) {
       let this_player = i + 1;
 
+
+      let name = this.app.keys.returnUsername(this.game.players[i]);
+      let identicon = this.app.keys.returnIdenticon(this.game.players[i]);
+
+      if (name != "") {
+        if (name.indexOf("@") > 0) {
+          name = name.substring(0, name.indexOf("@"));
+        }
+      }
+      //>>>>>>>>Improving HUD display
       if (this.game.player == this_player) {
         html += `
           <div class="player">
-            <span class="player_name">Player ${this.game.player} (you)</span>
+            <img class="player-identicon" src="${identicon}">
+            <span class="player_name">Me (Player ${this.game.player})</span>
             <span class="player_score" id="score_${this_player}"> ${this.game.score[i]} </span>
           </div>
         `;
@@ -641,7 +653,8 @@ class Wordblocks extends GameTemplate {
         op++;
         html += `
           <div class="player">
-            <span class="player_name">${opponent.substring(0, 16)}</span>
+            <img class="player-identicon" src="${identicon}">
+            <span class="player_name">Player ${this_player}: ${name}</span>
             <span class="player_score" id="score_${this_player}"> ${this.game.score[i]} </span>
           </div>
         `;
@@ -881,10 +894,12 @@ class Wordblocks extends GameTemplate {
         $('#tiles')[0].appendChild($('#tiles')[0].childNodes[Math.random() * i | 0]);
       }
     });
+    //Make tile sortable each round>>>>>
+    /*So we aren't sure if we want to re-up these each time we add events, or once during initialization...
     $('#tiles').sortable();
     $('#tiles').disableSelection();
     //$(window).resize(function () { resizeBoard(); });
-
+    */
     } catch (err) {}
   }
 


### PR DESCRIPTION
Okay, I think I sorted out all the UI improvements I wanted to tackle for Wordblocks #252  

- Smooth dragging of tiles in rack.
- Double click to mark for deletion.
- Click to select and move to board. (with a floating copy of tile attached to mouse cursor).
- Updated user messaging when shifting into or out of deletion or selection mode.
- Preserved legacy commands (sometimes it is easier to just click on a square and type your entry).
- Dummy-proof single tile play (figures out correct orientation to make a word work)
- Improved logging of the whole played word (instead of just the user input)
- Dragging tiles in rack doesn't accidentally select them

