### PR TITLE
Cleaning up css 

### DIFF
--- a/lib/saito/ui/game-playerbox/game-playerbox.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.js
@@ -1,66 +1,37 @@
-/*
-  A Class to Make Playerboxes for displaying information about all the players in the game
-  Basic template: 
-    --- a Head for the Player's identicon and name
-    --- a Div for Information (formatted to the players specification)
-    --- a Div for Player log (to include additional information), 
-          this defaults to status for the player and is used by some games for interactive controls
-    --- a Div for graphical elements, such a dealt hand of cards
-
-  API:
-    render(app, game) 
-        -- creates the player boxes and assigns unique ids
-           default ids are based on positions around a table, 
-           but you can assign an array to game.seats to define 
-           your own numbering system for the players
-    hide()            
-        -- hides all the playerboxes
-    show()
-        -- shows all the playerboxes
-    attachEvents(app, data)
-        -- makes playerboxes draggable (via internal coding, not jquery)
-    groupOpponents()  
-        -- adds a wrapper around the playerboxes which are not the player 
-           (the first seat in the array) so that they are displayed together
-    returnPlayerBoxArray()
-        -- returns the seating chart for the playerboxes
-    returnViewBoxArray()
-        -- *LEGACY* returns a seating chart assuming that the player is 
-            not an active player and has no playerbox of their own    
-    addClassAll(classname, flag)
-        -- adds a classname to all the playerboxes, if flag is set to true (default)
-           gives each playerbox a unique classname sufixed with their seat #
-    addClass(classname, player) 
-        -- adds a classname to the playerbox for the specified player 
-    addGraphicClass(classname)
-        -- adds a classname to the graphic contained div inside each playerbox
-    refreshName(player, name)
-        -- displays given (or wallet) name in the header of the playerbox 
-          (also inserts player's identicon)
-    refreshInfo(html, player)
-    refreshGraphic(html, player)
-    refreshLog(html, player)
-        -- inserts given html into the associated division of the player box, 
-           defaults to the player if no number specified
-    showInfo(player)
-    hideInfo(player)
-        -- toggles visibility of the given player's playerbox info div (to make more room for log)
-
-*/
-
 const GamePlayerBoxTemplate = require('./game-playerbox.template');
 
+/**
+ * A Class to Make Playerboxes for displaying information about all the players in the game
+ * Class converts Player numbers from game into user-oriented ids to distinguish this player from the opponents
+ * 
+ * Basic template: 
+ *   Name --- a Head for the Player's identicon and name
+ *   Info --- a Div for Information (formatted to the players specification)
+ *   Log --- a Div for Player log (to include additional information), 
+ *         this defaults to status for the player and is used by some games for interactive controls
+ *   Graphic --- a Div for graphical elements, such a dealt hand of cards
+ *
+ *   You may insert whatever HTML you want into Info, Log, or Graphic. 
+ *   Info can be hidden/displayed independently of the Player-Box
+ *   Graphic can be assigned classnames for more flexible display behavior (such as outside the player-box)
+ */
 class GamePlayerBox {
 
+    /**
+     *  @constructor 
+     *  @param app - Saito app
+     */
     constructor(app) {
       this.app = app;
       this.game_mod = null;
     }
 
 
-    /*
-      Test is DOM contains element ID player-info-1, if not 
-      create all the player boxes, positioned by PlayersBoxArray 
+    /**
+     * Creates player boxes according to number of players in game
+     * Automatically assigns unique id #s to divs in DOM, but can be specified by setting a seats property in game object
+     * @param app - Saito app
+     * @param game_mod - the game object
     */
     render(app, game_mod) {
       this.game_mod = game_mod;
@@ -70,47 +41,65 @@ class GamePlayerBox {
          
         for (let i = 1; i <= game_mod.game.players.length; i++) {
           let player = this._playerBox(i);
-          if (!document.getElementById("player-box-"+player)) {
+          if (!document.getElementById(`player-box-${player}`)) {
             let pBox = app.browser.htmlToElement(GamePlayerBoxTemplate(player));
             if (document.querySelector(".main")) {
               document.querySelector(".main").append(pBox);
             } else { 
-	      document.body.append(pBox);
-	    }
+	            document.body.append(pBox);
+	          }
             this.refreshName(i); //Player names included in box by default
           }
-          if (document.getElementById(("player-box-"+player))) {
-            document.getElementById(("player-box-"+player)).style.display = "block";
+          if (document.getElementById((`player-box-${player}`))) {
+            document.getElementById((`player-box-${player}`)).style.display = "block";
           }
         }
       } catch (err) {console.log("Render error: ",err);}
     }
 
 
-    /*
-    Hide all playerboxes (selected by ID)
-    */
+    /** Doesn't do anything */
+    attachEvents(app, data=null) {
+      
+    }
+
+    /**
+     * Adds draggability to all the playerboxes (not a default setting)
+     */
+    makeDraggable(){
+      try{
+           for (let i = 1; i <= this.game_mod.game.players.length; i++) {
+            let player = this._playerBox(i);
+            if (!document.getElementById(`player-box-${player}`) || !document.getElementById(`player-box-head-${player}`)){
+              console.log("Null DOM elements for Playerbox");
+              return -1;
+            }
+            app.browser.makeDraggable(`player-box-${player}`,`player-box-head-${player}`);
+            document.querySelector(`#player-box-head-${player}`).style.cursor="grab";
+          }
+      }catch(err){console.log("Events error:",err);}
+    }
+
+    /**  Hide all Player-boxes  */
     hide() {
       try {
         for (let i = 1; i <= this.game_mod.game.players.length; i++) {
-	        let player = this._playerBox(i);
-          if (document.getElementById(("player-box-"+player))) {
-            document.getElementById(("player-box-"+player)).style.display = "none";
-	        }
-	       }
+          let player = this._playerBox(i);
+          if (document.getElementById((`player-box-${player}`))) {
+            document.getElementById((`player-box-${player}`)).style.display = "none";
+          }
+         }
       } catch (err) {
       }
     }
 
-    /*
-    Show all playerboxes (selected by ID)
-    */
+    /** Show all playerboxes */
     show() {
       try {
         for (let i = 1; i <= this.game_mod.game.players.length; i++) {
           let player = this._playerBox(i);
-          if (document.getElementById(("player-box-"+player))) {
-            document.getElementById(("player-box-"+player)).style.display = "block";
+          if (document.getElementById((`player-box-${player}`))) {
+            document.getElementById((`player-box-${player}`)).style.display = "block";
           }
          }
       } catch (err) {
@@ -118,22 +107,8 @@ class GamePlayerBox {
     }
 
 
-    attachEvents(app, data=null) {
-      //try{
-           for (let i = 1; i <= this.game_mod.game.players.length; i++) {
-            let player = this._playerBox(i);
-            if (!document.getElementById("player-box-"+player) || !document.getElementById("player-box-head-"+player)){
-              console.log("Null DOM elements for Playerbox");
-              return -1;
-            }
-            app.browser.makeDraggable("player-box-"+player,"player-box-head-"+player);
-            document.querySelector("#player-box-head-"+player).style.cursor="grab";
-          }
-      //}catch(err){console.log("Events error:",err);}
-    }
-
-    /*
-    Create a div wrapper for 
+    /**
+    * Groups all "opponent" playerboxes into a wrapper division
     */
     groupOpponents(){
       let html = `<div class="opponents" id="opponentbox"></div>`;
@@ -161,8 +136,9 @@ class GamePlayerBox {
       this.app.browser.makeDraggable("opponentbox");
     }
 
-    /*
-    Given the game_module-based player number, determine where they sit around the table
+    /**
+    * @param {int} pnum - player number, e.g. {1, 2, ... # of players}
+    * Converts the player number to a "seat position" This player is always 1, unless you render with game.seats
     */
     _playerBox(pnum){
       if (pnum<=0) return 1;
@@ -175,8 +151,10 @@ class GamePlayerBox {
       return player_box[seat];
     }
 
-    /*
-
+    /**
+    * Returns either game.seats or the default poker table seating schedule
+    * 3 4 5 
+    * 2 1 6
     */
     returnPlayersBoxArray() {
 
@@ -192,9 +170,13 @@ class GamePlayerBox {
       }
 
       return player_box;
-
     }
 
+    /**
+    * Returns poker table seating schedule for observer mode 
+    * 3 4 5 
+    * 2 _ 6
+    */
     returnViewBoxArray() {
     
       let player_box = [];
@@ -208,10 +190,11 @@ class GamePlayerBox {
   
     }
 
-    /*
-    Classes p1-p6 fix the player boxes around the screen like a card table, 
-    so you can provide a class-name stub to generate x1, x2, ... classes or 
-    use a universal class name for all the boxes to customize the css 
+    /**
+    * Adds a class to each of the playerboxes
+    * @param {string} className - user defined class (for css or DOM hacking)
+    * @param {boolean} isStub - flag for whether to add a numerical suffic to classname so you can tell apart playerboxes
+    * This function [addClassAll("poker-seat")] is required for Player-Box to accurately render around a card table
     */
     addClassAll(className, isStub = true){
       if (isStub){
@@ -227,6 +210,11 @@ class GamePlayerBox {
       }
     }
 
+    /**
+     * Individually a classname to one of the playerboxes
+     * @param {string} className - name of class
+     * @param {int} player - the player number (according to game), -1 means this player 
+     */
     addClass(className, player = -1){
       let selector = "#player-box-"+this._playerBox(player);
       let box = document.querySelector(selector);
@@ -234,11 +222,35 @@ class GamePlayerBox {
         box.classList.add(className);
     }
 
-  
+    /**
+    * Add a class name to the "graphical" subdivision of each playerbox
+    * @param {string} className - name of class
+    */
+    addGraphicClass(className){
+      let playerBoxes = document.querySelectorAll(".player-box-graphic");
+      for (let hand of playerBoxes){
+        hand.classList.remove(className);
+        hand.classList.add(className);
+      }
+    }
 
 
+    /*
+    * Helper class for updating different sections of Player-Box
+    */
+    _updateDiv(selector, html){
+      let div = document.querySelector(selector);
+      if (div)
+        div.innerHTML = html; 
+      else console.log(selector + " not found");
+    }
+
+    /**
+     * Refresh Player Name (Player-Boxes show Identicon + Username in top line)
+     * @param {int} pnum - the player number (according to game), -1 means this player 
+     * @param {string} name - a user-provided name. If blank, will use whatever name is associated with the wallet
+    */       
     refreshName(pnum, name="") {
-
       let selector = "#player-box-head-"+this._playerBox(pnum);
       let identicon = "";
 
@@ -258,51 +270,38 @@ class GamePlayerBox {
       this._updateDiv(selector,html);
     }
 
-    _updateDiv(selector, html){
-      let div = document.querySelector(selector);
-      if (div)
-        div.innerHTML = html; 
-      else console.log(selector + " not found");
-    }
-
-    /*
-    Different games may attach classes to the graphics container to customize the graphical display
-    Card games will use hand/tinyhand
-    Other games will use ...
+    /**
+    * Insert provided html into the graphic subdivision of playerbox
+    * @param {string} html - information to be displayed
+    * @param {int} pnum - the player number (according to game), -1 means this player 
     */
-    addGraphicClass(className){
-      let playerBoxes = document.querySelectorAll(".player-box-graphic");
-      for (let hand of playerBoxes){
-        hand.classList.remove(className);
-        hand.classList.add(className);
-      }
-    }
-
-    /*
-    For all the refresh elements of playerbox, we default to this player (in the 1 seat)
-    */
-
     refreshGraphic(html, pnum=-1) {
       this._updateDiv("#player-box-graphic-"+this._playerBox(pnum), html);
     }
 
 
-  /*
-    Log (plog) is another section of the playerbox for status/plog information, 
-    also where we can insert menu options for player controls
+    /**
+    * Insert provided html into the log subdivision of playerbox
+    * @param {string} html - information to be displayed
+    * @param {int} pnum - the player number (according to game), -1 means this player 
     */
     refreshLog(html, pnum=-1) {
       this._updateDiv("#player-box-log-"+this._playerBox(pnum), html);
     }
 
-    /*
-    Info is a hide-able section of the playerbox, where we can display the player's score and role in this round
-    (We typically hide it to clear up space when presenting menu options through the log, see below)
+    /**
+    * Insert provided html into the log subdivision of playerbox
+    * @param {string} html - information to be displayed
+    * @param {int} pnum - the player number (according to game), -1 means this player 
     */
     refreshInfo(html, pnum=-1){
       this._updateDiv("#player-box-info-"+this._playerBox(pnum), html);
     }
 
+    /**
+    * Hide the info subdivision of a given player-box
+    * @param {int} pnum - the player number (according to game), -1 means this player 
+    */
     hideInfo(pnum=-1){
       let selector = "#player-box-info-"+this._playerBox(pnum);
       try{
@@ -310,6 +309,10 @@ class GamePlayerBox {
       }catch(err){}
     }
 
+    /**
+    * Hide the info subdivision of a given player-box
+    * @param {int} pnum - the player number (according to game), -1 means this player 
+    */
     showInfo(pnum=-1){
       let selector = "#player-box-info-"+this._playerBox(pnum);
       try{
@@ -317,9 +320,6 @@ class GamePlayerBox {
       }catch(err){
       }
     }
-
-    
-
 }
 
 module.exports = GamePlayerBox

--- a/lib/saito/ui/game-playerbox/game-playerbox.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.js
@@ -7,8 +7,44 @@
           this defaults to status for the player and is used by some games for interactive controls
     --- a Div for graphical elements, such a dealt hand of cards
 
-    Use render to create the playerboxes
-    Use attachEvents to make them movable
+  API:
+    render(app, game) 
+        -- creates the player boxes and assigns unique ids
+           default ids are based on positions around a table, 
+           but you can assign an array to game.seats to define 
+           your own numbering system for the players
+    hide()            
+        -- hides all the playerboxes
+    show()
+        -- shows all the playerboxes
+    attachEvents(app, data)
+        -- makes playerboxes draggable (via internal coding, not jquery)
+    groupOpponents()  
+        -- adds a wrapper around the playerboxes which are not the player 
+           (the first seat in the array) so that they are displayed together
+    returnPlayerBoxArray()
+        -- returns the seating chart for the playerboxes
+    returnViewBoxArray()
+        -- *LEGACY* returns a seating chart assuming that the player is 
+            not an active player and has no playerbox of their own    
+    addClassAll(classname, flag)
+        -- adds a classname to all the playerboxes, if flag is set to true (default)
+           gives each playerbox a unique classname sufixed with their seat #
+    addClass(classname, player) 
+        -- adds a classname to the playerbox for the specified player 
+    addGraphicClass(classname)
+        -- adds a classname to the graphic contained div inside each playerbox
+    refreshName(player, name)
+        -- displays given (or wallet) name in the header of the playerbox 
+          (also inserts player's identicon)
+    refreshInfo(html, player)
+    refreshGraphic(html, player)
+    refreshLog(html, player)
+        -- inserts given html into the associated division of the player box, 
+           defaults to the player if no number specified
+    showInfo(player)
+    hideInfo(player)
+        -- toggles visibility of the given player's playerbox info div (to make more room for log)
 
 */
 
@@ -51,14 +87,32 @@ class GamePlayerBox {
     }
 
 
+    /*
+    Hide all playerboxes (selected by ID)
+    */
     hide() {
       try {
         for (let i = 1; i <= this.game_mod.game.players.length; i++) {
-	  let player = this._playerBox(i);
+	        let player = this._playerBox(i);
           if (document.getElementById(("player-box-"+player))) {
             document.getElementById(("player-box-"+player)).style.display = "none";
-	  }
-	}
+	        }
+	       }
+      } catch (err) {
+      }
+    }
+
+    /*
+    Show all playerboxes (selected by ID)
+    */
+    show() {
+      try {
+        for (let i = 1; i <= this.game_mod.game.players.length; i++) {
+          let player = this._playerBox(i);
+          if (document.getElementById(("player-box-"+player))) {
+            document.getElementById(("player-box-"+player)).style.display = "block";
+          }
+         }
       } catch (err) {
       }
     }

--- a/lib/saito/ui/game-playerbox/game-playerbox.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.js
@@ -3,6 +3,8 @@ const GamePlayerBoxTemplate = require('./game-playerbox.template');
 /**
  * A Class to Make Playerboxes for displaying information about all the players in the game
  * Class converts Player numbers from game into user-oriented ids to distinguish this player from the opponents
+ * For example, in a 2-player game each player's own playerbox will have -1 suffixed to all the div id's and the opponent's playerbox will have -4 as the suffix on each of the div ids 
+ * This player has a status class added by default
  * 
  * Basic template: 
  *   Name --- a Head for the Player's identicon and name
@@ -11,6 +13,7 @@ const GamePlayerBoxTemplate = require('./game-playerbox.template');
  *         this defaults to status for the player and is used by some games for interactive controls
  *   Graphic --- a Div for graphical elements, such a dealt hand of cards
  *
+ *   Name is the only mandatory and pre-defined part of Player-Box
  *   You may insert whatever HTML you want into Info, Log, or Graphic. 
  *   Info can be hidden/displayed independently of the Player-Box
  *   Graphic can be assigned classnames for more flexible display behavior (such as outside the player-box)
@@ -35,13 +38,11 @@ class GamePlayerBox {
     */
     render(app, game_mod) {
       this.game_mod = game_mod;
-      
-      try {
-        let playerboxes = [];
-         
+      try { 
         for (let i = 1; i <= game_mod.game.players.length; i++) {
           let player = this._playerBox(i);
           if (!document.getElementById(`player-box-${player}`)) {
+            //let isItMe = (this.returnPlayersBoxArray().indexOf(player) == 0); //Include status in box of the controlling player
             let pBox = app.browser.htmlToElement(GamePlayerBoxTemplate(player));
             if (document.querySelector(".main")) {
               document.querySelector(".main").append(pBox);
@@ -74,7 +75,7 @@ class GamePlayerBox {
               console.log("Null DOM elements for Playerbox");
               return -1;
             }
-            app.browser.makeDraggable(`player-box-${player}`,`player-box-head-${player}`);
+            this.app.browser.makeDraggable(`player-box-${player}`,`player-box-head-${player}`);
             document.querySelector(`#player-box-head-${player}`).style.cursor="grab";
           }
       }catch(err){console.log("Events error:",err);}
@@ -119,8 +120,8 @@ class GamePlayerBox {
       let opponents = this.returnPlayersBoxArray();
       opponents.shift(); //Remove the active player
       for (let o of opponents){
-        let pbo = document.querySelector("#player-box-"+o);
-        let pbho = document.querySelector("#player-box-head-"+o);
+        let pbo = document.querySelector(`#player-box-${o}`);
+        let pbho = document.querySelector(`#player-box-head-${o}`);
         if (!pbo || !pbho){
           console.log("DOM failure");
           return;
@@ -141,13 +142,19 @@ class GamePlayerBox {
     * Converts the player number to a "seat position" This player is always 1, unless you render with game.seats
     */
     _playerBox(pnum){
-      if (pnum<=0) return 1;
       let player_box = this.returnPlayersBoxArray();
+
+      if (pnum<=0) {
+        return player_box[0]; //Default is first position
+      }
+      
       //Shift players in Box Array according to whose browser, so that I am always in seat 1
-      let prank = 1+this.game_mod.game.players.indexOf(this.app.wallet.returnPublicKey());
+      let prank = 1+this.game_mod.game.players.indexOf(this.app.wallet.returnPublicKey()); //Equivalent to game_mod.player ?
       let seat = pnum - prank;
       
-      if (seat < 0) { seat += this.game_mod.game.players.length }
+      if (seat < 0) { 
+        seat += this.game_mod.game.players.length 
+      }
       return player_box[seat];
     }
 
@@ -200,7 +207,9 @@ class GamePlayerBox {
       if (isStub){
         for (let i = 1; i <= 6; i++){
           let box = document.querySelector(`#player-box-${i}`);
-          if (box) box.classList.add(`${className}${i}`);
+          if (box) {
+            box.classList.add(`${className}${i}`);
+          }
         }
       }else{
         let boxes = document.querySelectorAll(".player_box");
@@ -218,8 +227,9 @@ class GamePlayerBox {
     addClass(className, player = -1){
       let selector = "#player-box-"+this._playerBox(player);
       let box = document.querySelector(selector);
-      if (box)
+      if (box){
         box.classList.add(className);
+      }
     }
 
     /**
@@ -234,14 +244,25 @@ class GamePlayerBox {
       }
     }
 
+    /**
+     * Adds a "status" class to player-box log of this player so that updateStatus functions
+     * render in the playerbox
+     */ 
+    addStatus(){
+      let div = document.querySelector(`#player-box-log-${this._playerBox(-1)}`);
+      if (div){
+        div.classList.add("status");
+      }
+    }
 
     /*
     * Helper class for updating different sections of Player-Box
     */
     _updateDiv(selector, html){
       let div = document.querySelector(selector);
-      if (div)
+      if (div){
         div.innerHTML = html; 
+      }
       else console.log(selector + " not found");
     }
 
@@ -276,7 +297,7 @@ class GamePlayerBox {
     * @param {int} pnum - the player number (according to game), -1 means this player 
     */
     refreshGraphic(html, pnum=-1) {
-      this._updateDiv("#player-box-graphic-"+this._playerBox(pnum), html);
+      this._updateDiv(`#player-box-graphic-${this._playerBox(pnum)}`, html);
     }
 
 
@@ -286,7 +307,7 @@ class GamePlayerBox {
     * @param {int} pnum - the player number (according to game), -1 means this player 
     */
     refreshLog(html, pnum=-1) {
-      this._updateDiv("#player-box-log-"+this._playerBox(pnum), html);
+      this._updateDiv(`#player-box-log-${this._playerBox(pnum)}`, html);
     }
 
     /**
@@ -295,7 +316,7 @@ class GamePlayerBox {
     * @param {int} pnum - the player number (according to game), -1 means this player 
     */
     refreshInfo(html, pnum=-1){
-      this._updateDiv("#player-box-info-"+this._playerBox(pnum), html);
+      this._updateDiv(`#player-box-info-${this._playerBox(pnum)}`, html);
     }
 
     /**

--- a/lib/saito/ui/game-playerbox/game-playerbox.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.js
@@ -61,8 +61,34 @@ class GamePlayerBox {
 
     /** Doesn't do anything */
     attachEvents(app, data=null) {
+        let chatmod = null;
+        let pb_self = this;
+          for (let i = 0; i < this.app.modules.mods.length; i++){
+            if (this.app.modules.mods[i].slug === "chat") {
+              chatmod = this.app.modules.mods[i];
+            }
+          } 
       
-    }
+        for (let player = 1; player <= this.game_mod.game.players.length; player++) {
+           let boxId = this._playerBox(player);
+           $(`#player-box-head-${boxId}`).off();
+           $(`#player-box-head-${boxId}`).on("dblclick",function(){
+            //Code to launch a private chat window
+            let members = [pb_self.game_mod.game.players[player-1], pb_self.app.wallet.returnPublicKey()].sort();
+            let gid = pb_self.app.crypto.hash(members.join('_'));
+            let newgroup = chatmod.createChatGroup(members, `Player ${player}`);
+              if (newgroup) {
+                chatmod.addNewGroup(newgroup);
+                chatmod.sendEvent('chat-render-request', {});
+                chatmod.saveChat();
+                chatmod.openChatBox(newgroup.id);
+              } else {
+                chatmod.sendEvent('chat-render-request', {});
+                chatmod.openChatBox(gid);
+              }
+               });
+            }
+          }
 
     /**
      * Adds draggability to all the playerboxes (not a default setting)

--- a/lib/saito/ui/game-playerbox/game-playerbox.template.js
+++ b/lib/saito/ui/game-playerbox/game-playerbox.template.js
@@ -4,7 +4,7 @@ module.exports = GamePlayerBoxTemplate = (player_num) => {
       <div class="player-box-graphic" id="player-box-graphic-${player_num}"></div> 
       <div class="player-box-head" id="player-box-head-${player_num}"></div>
       <div class="player-box-info" id="player-box-info-${player_num}"></div>
-      <div class="plog ${(player_num==1)? "status":""}" id="player-box-log-${player_num}"></div>
+      <div class="plog" id="player-box-log-${player_num}"></div>
       </div>
     </div>
   `;

--- a/mods/blackjack/blackjack.js
+++ b/mods/blackjack/blackjack.js
@@ -193,10 +193,10 @@ toggleIntro() {
     this.log.attachEvents(app, this);
 
     this.playerbox.render(app, this);
+    this.playerbox.attachEvents(app, this); //empty function
     this.playerbox.addClassAll("poker-seat-",true);
     this.playerbox.addGraphicClass("hand");   
     this.playerbox.addGraphicClass("tinyhand");   
-    //this.playerbox.attachEvents(app.this);
   
   }
 

--- a/mods/blackjack/blackjack.js
+++ b/mods/blackjack/blackjack.js
@@ -197,6 +197,7 @@ toggleIntro() {
     this.playerbox.addClassAll("poker-seat-",true);
     this.playerbox.addGraphicClass("hand");   
     this.playerbox.addGraphicClass("tinyhand");   
+    this.playerbox.addStatus(); //enable update Status to display in playerbox
   
   }
 

--- a/mods/blackjack/blackjack.js
+++ b/mods/blackjack/blackjack.js
@@ -193,7 +193,7 @@ toggleIntro() {
     this.log.attachEvents(app, this);
 
     this.playerbox.render(app, this);
-    this.playerbox.addClassAll("p",true);
+    this.playerbox.addClassAll("poker-seat-",true);
     this.playerbox.addGraphicClass("hand");   
     this.playerbox.addGraphicClass("tinyhand");   
     //this.playerbox.attachEvents(app.this);
@@ -1159,10 +1159,8 @@ toggleIntro() {
     try {
       if (hide_info == 0) {
         this.playerbox.showInfo();
-        //document.querySelector(".p1 > .info").style.display = "block";
       } else {
         this.playerbox.hideInfo();
-        //document.querySelector(".p1 > .info").style.display = "none";
       }
 
       if (this.lock_interface == 1) { return; }

--- a/mods/blackjack/web/style.css
+++ b/mods/blackjack/web/style.css
@@ -124,7 +124,7 @@ body {
     width: 8vw;
   }
 
-  .player-info.p1 {
+  .player-info.poker-seat-1 {
     height: 40vh;
     width: 30vw;
   }
@@ -155,7 +155,7 @@ body {
   }
 
 
-  .player-info.p1 {
+  .player-info.poker-seat-1 {
     height: 25vh;
     width: 60vw;
   }
@@ -181,7 +181,7 @@ body {
     width: 35vw;
   }
 
-  .p4 .hand, .p3 .hand, .p2 .hand {
+  .poker-seat-4 .hand, .poker-seat-3 .hand, .poker-seat-2 .hand {
     right: 15vw;
     top: 10vh;
   }
@@ -193,23 +193,23 @@ body {
 
 @media screen and (orientation: portrait) and (max-width: 450px) {
 
-  .player-info.p2 {
+  .player-info.poker-seat-2 {
     display: none;
     visibility: hidden;
   }
-  .player-info.p3 {
+  .player-info.poker-seat-3 {
     display: none;
     visibility: hidden;
   }
-  .player-info.p4 {
+  .player-info.poker-seat-4 {
     display: none;
     visibility: hidden;
   }
-  .player-info.p5 {
+  .player-info.poker-seat-5 {
     display: none;
     visibility: hidden;
   }
-  .player-info.p6 {
+  .player-info.poker-seat-6 {
     display: none;
     visibility: hidden;
   }
@@ -220,134 +220,3 @@ body {
   }
 
 }
-
-
-/*
-  This CSS is duplicated in game.css
-*/
-
-/*.player-info {
-  width: min(25vh,25vw);
-  height: 20vh;
-  background-color: #4448;
-  color: #fff;
-  padding: 1em;
-  position: absolute;
-}
-
-.player-info.p1 {
-  height: 30vh;
-}
-.player-info .status {
-  font-size: 1.25em;
-}
-
-
-.player-info-name {
-  font-size: 3vh;
-  font-weight: bold;
-  text-align: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
-.player-info-chips {
-  padding: 0.5em;
-  text-align: center;
-  font-size: 3vh;
-}
-
-.dealer .player-notice{
-  background-color: #0004;
-  border-top: 1px solid #efefef;
-  border-bottom: 1px solid #efefef;
-}
-
-
-.p1 .hand {
-  display: none;
-}
-
-.p4 .hand, .p3 .hand, .p2 .hand {
-  right: 15vh;
-  top: 2vh;
-}
-
-.p5 .hand, .p6 .hand {
-  left: 24vh;
-  top: 2vh;
-}
-
-.player-info-hand .card {
-  width: 12vh;
-  position: absolute;
-}
-*/
-
-/*
-
-.cardfan {
-  position: absolute;
-  top: 70vh;
-  left: 10vw;
-}
-
-.cardfan .card {
-  position: absolute;
-  width: 17.5vh;
-}
-
-.card:nth-child(1n+2) {
-  left: -130px;
-} 
-
-.cardfan>.card:nth-child(1) {
-  transform: rotate(-20deg);
-  left: 0px;
-}
-
-.cardfan>.card:nth-child(2) {
-  transform: rotate(-10deg);
-  left: 3vh;
-}
-
-.cardfan>.card:nth-child(3) {
-  transform: rotate(0deg);
-  left: 6vh;
-}
-
-.cardfan>.card:nth-child(4) {
-  transform: rotate(10deg);
-  left: 9vh;
-}
-
-.cardfan>.card:nth-child(5) {
-  transform: rotate(20deg);
-  left: 12vh;
-}
-
-.hand>.card:nth-child(1) {
-  transform: rotate(-20deg);
-  left: 0px;
-}
-
-.hand>.card:nth-child(2) {
-  transform: rotate(-10deg);
-  left: 2vh;
-}
-
-.hand>.card:nth-child(3) {
-  transform: rotate(0deg);
-  left: 4vh;
-}
-
-.hand>.card:nth-child(4) {
-  transform: rotate(10deg);
-  left: 6vh;
-}
-
-.hand>.card:nth-child(5) {
-  transform: rotate(20deg);
-  left: 8vh;
-} */

--- a/mods/gametestsuite/gametestsuite.js
+++ b/mods/gametestsuite/gametestsuite.js
@@ -432,6 +432,7 @@ class GameTestSuite extends GameTemplate {
   add_player_boxes_test(app) {
     if (this.game_playerboxes_visible == 0) {
       this.playerbox.render(app, this);
+      this.playerbox.addClassAll("poker-seat-",true); //Have to manually add a class for positioning
       this.playerbox.attachEvents(app, this);
       for (let i = 0; i < this.game.players.length; i++) {
         this.playerbox.refreshName(i+1);

--- a/mods/hearts/web/index.html
+++ b/mods/hearts/web/index.html
@@ -33,21 +33,21 @@
 
         <div class="pile" id="pile"></div>
 
-        <div class="player-info p1" id="player-info-1">
+        <div class="player-info poker-seat-1" id="player-info-1">
           <div class="info"></div>
           <div class="plog status"></div>
         </div>
 
-        <div class="player-info p2" id="player-info-2">
+        <div class="player-info poker-seat-2" id="player-info-2">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
 
-        <div class="player-info p3" id="player-info-3">
+        <div class="player-info poker-seat-3" id="player-info-3">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
-        <div class="player-info p4" id="player-info-4">
+        <div class="player-info poker-seat-4" id="player-info-4">
           <div class="info"></div>
           <div class="plog"></div>
         </div>

--- a/mods/poker/poker.js
+++ b/mods/poker/poker.js
@@ -2810,9 +2810,9 @@ console.log("STATE: " + JSON.stringify(state));
 
     try {
     if (hide_info == 0) {
-      document.querySelector(".p1 > .info").style.display = "block";
+      document.querySelector(".poker-seat-1 > .info").style.display = "block";
     } else {
-      document.querySelector(".p1 > .info").style.display = "none";
+      document.querySelector(".poker-seat-1 > .info").style.display = "none";
     }
 
     if (this.lock_interface == 1) { return; }

--- a/mods/poker/web/index.html
+++ b/mods/poker/web/index.html
@@ -37,29 +37,29 @@
         <div class="pot" id="pot"></div>
         <div class="dealer" id="dealer"></div>
 
-        <div class="player-info p1" id="player-info-1">
+        <div class="player-info poker-seat-1" id="player-info-1">
           <div class="info"></div>
           <div class="plog status"></div>
         </div>
 
-        <div class="player-info p2" id="player-info-2">
+        <div class="player-info poker-seat-2" id="player-info-2">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
 
-        <div class="player-info p3" id="player-info-3">
+        <div class="player-info poker-seat-3" id="player-info-3">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
-        <div class="player-info p4" id="player-info-4">
+        <div class="player-info poker-seat-4" id="player-info-4">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
-        <div class="player-info p5" id="player-info-5">
+        <div class="player-info poker-seat-5" id="player-info-5">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
-        <div class="player-info p6" id="player-info-6">
+        <div class="player-info poker-seat-6" id="player-info-6">
           <div class="info"></div>
           <div class="plog"></div>
         </div>

--- a/mods/poker/web/style.css
+++ b/mods/poker/web/style.css
@@ -83,7 +83,7 @@ body {
   position: absolute;
 }
 
-.player-info.p1 {
+.player-info.poker-seat-1 {
   height: 30vh;
 }
 .player-info .status {
@@ -106,16 +106,16 @@ body {
   overflow: hidden;
 }
 
-.p1 .hand {
+.poker-seat-1 .hand {
   display: none;
 }
 
-.p4 .hand, .p3 .hand, .p2 .hand {
+.poker-seat-4 .hand, .poker-seat-3 .hand, .poker-seat-2 .hand {
   right: 15vh;
   top: 2vh;
 }
 
-.p5 .hand, .p6 .hand {
+.poker-seat-5 .hand, .poker-seat-6 .hand {
   left: 24vh;
   top: 2vh;
 }
@@ -293,7 +293,7 @@ body {
     font-size: 1.4em;
   }
 
-  .player-info.p1 {
+  .player-info.poker-seat-1 {
     height: 40vh;
     width: 30vw;
   }
@@ -333,7 +333,7 @@ body {
     font-size: 2.4em;
   }
 
-  .player-info.p1 {
+  .player-info.poker-seat-1 {
     height: 25vh;
     width: 60vw;
   }
@@ -373,7 +373,7 @@ body {
     width: 35vw;
   }
 
-  .p4 .hand, .p3 .hand, .p2 .hand {
+  .poker-seat-4 .hand, .poker-seat-3 .hand, .poker-seat-2 .hand {
     right: 15vw;
     top: 10vh;
   }
@@ -391,23 +391,23 @@ body {
 
 @media screen and (orientation: portrait) and (max-width: 450px) {
 
-  .player-info.p2 {
+  .player-info.poker-seat-2 {
     display: none;
     visibility: hidden;
   }
-  .player-info.p3 {
+  .player-info.poker-seat-3 {
     display: none;
     visibility: hidden;
   }
-  .player-info.p4 {
+  .player-info.poker-seat-4 {
     display: none;
     visibility: hidden;
   }
-  .player-info.p5 {
+  .player-info.poker-seat-5 {
     display: none;
     visibility: hidden;
   }
-  .player-info.p6 {
+  .player-info.poker-seat-6 {
     display: none;
     visibility: hidden;
   }

--- a/mods/president/web/index.html
+++ b/mods/president/web/index.html
@@ -33,27 +33,27 @@
       
       <div class="gameboard" id="gameboard">
 
-        <div class="player-info p1" id="player-info-1">
+        <div class="player-info poker-seat-1" id="player-info-1">
           <div class="info"></div>
           <div class="plog" id="log"></div>
         </div>
-        <div class="player-info p2" id="player-info-2">
+        <div class="player-info poker-seat-2" id="player-info-2">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
-        <div class="player-info p3" id="player-info-3">
+        <div class="player-info poker-seat-3" id="player-info-3">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
-        <div class="player-info p4" id="player-info-4">
+        <div class="player-info poker-seat-4" id="player-info-4">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
-        <div class="player-info p5" id="player-info-5">
+        <div class="player-info poker-seat-5" id="player-info-5">
           <div class="info"></div>
           <div class="plog"></div>
         </div>
-        <div class="player-info p6" id="player-info-6">
+        <div class="player-info poker-seat-6" id="player-info-6">
           <div class="info"></div>
           <div class="plog"></div>
         </div>

--- a/mods/wuziqi/wuziqi.js
+++ b/mods/wuziqi/wuziqi.js
@@ -26,7 +26,7 @@ class Wuziqi extends GameTemplate {
         this.moves = [];
         this.bestof = 1;
 
-        this.seats = [2,5]
+        this.seats = [2,5];
 
         return this;
     }
@@ -167,8 +167,8 @@ class Wuziqi extends GameTemplate {
 
         //Player Boxes
         this.playerbox.render(this.app,this);
-        this.playerbox.addClass("me",this.game.player-1);
-        this.playerbox.addClass("notme",this.game.player);
+        this.playerbox.addClass("me",this.game.player);
+        this.playerbox.addClass("notme",3-this.game.player);
         this.playerbox.attachEvents(this.app);
         this.playerbox.makeDraggable(); //I think we still want to be able to move them
 
@@ -278,7 +278,7 @@ class Wuziqi extends GameTemplate {
             for (let j = 0; j < (roundsToWin - this.game.score[i]); j++) {
                 scoreHTML += `<img class="piece opaque30" src="img/${this.game.sides[i]}piece.png">`;
             }
-            this.playerbox.refreshInfo(scoreHTML,i);                        
+            this.playerbox.refreshInfo(scoreHTML,i+1);                        
         }
     }
 

--- a/mods/wuziqi/wuziqi.js
+++ b/mods/wuziqi/wuziqi.js
@@ -170,6 +170,7 @@ class Wuziqi extends GameTemplate {
         this.playerbox.addClass("me",this.game.player-1);
         this.playerbox.addClass("notme",this.game.player);
         this.playerbox.attachEvents(this.app);
+        this.playerbox.makeDraggable(); //I think we still want to be able to move them
 
         // Render board and set up values.
         try {

--- a/web/saito/lib/templates/game.css
+++ b/web/saito/lib/templates/game.css
@@ -602,50 +602,10 @@ ul li a {
 
 
 
-/******************************/
-/*** Poker / Cardgame Boxes ***/
-/******************************/
-.p6 , #player-box-6 {
-  left: 1em;
-  top: 60vh;
-  transform: translateY(-50%);
-}
 
-.p5 , #player-box-5 {
-  left: 1em;
-  top: 30vh;
-  transform: translateY(-50%);
-}
-
-.p4 , #player-box-4 {
-  left: 50vw;
-  top: 1em;
-  transform: translateX(-50%);
-}
-
-.p3 , #player-box-3 {
-  right: 1em;
-  top: 30vh;
-  transform: translateY(-50%);
-}
-
-.p2 , #player-box-2 {
-  right: 1em;
-  top: 60vh;
-  transform: translateY(-50%);
-}
-
-.p1 , #player-box-1 {
-  min-width: 30vh;
-  height: 32vh;
-  bottom: 1vh;
-  left: 50vw;
-  transform: translateX(-50%);
-  width: 16vw;
-  overflow-y: scroll;
-}
-
-
+/**********************************************/
+/*** Playerbox Layout (Often overwritten) ***/
+/**********************************************/
 .player-box {
   width: 25vh;
   height: 20vh;
@@ -654,10 +614,6 @@ ul li a {
   font-size: 1.25em;
   padding: 0.5em;
   position: absolute;
-}
-
-.player-box.p1 {
-  height: 30vh;
 }
 
 .player-box .plog {
@@ -697,25 +653,66 @@ ul li a {
   overflow: hidden;
 }
 
-.p1 .hand {
-  display: none;
-}
-
-.p4 .hand, .p3 .hand, .p2 .hand {
-  right: 15vh;
-  top: 2vh;
-}
-
-.p5 .hand, .p6 .hand {
-  left: 24vh;
-  top: 2vh;
-}
-
 .player-box-graphic .card {
   width: 12vh;
   position: absolute;
 }
 
+/******************************/
+/*** Poker / Cardgame Boxes ***/
+/******************************/
+.poker-seat-6{
+  left: 1em;
+  top: 60vh;
+  transform: translateY(-50%);
+}
+
+.poker-seat-5 {
+  left: 1em;
+  top: 30vh;
+  transform: translateY(-50%);
+}
+
+.poker-seat-4 {
+  left: 50vw;
+  top: 1em;
+  transform: translateX(-50%);
+}
+
+.poker-seat-3 {
+  right: 1em;
+  top: 30vh;
+  transform: translateY(-50%);
+}
+
+.poker-seat-2 {
+  right: 1em;
+  top: 60vh;
+  transform: translateY(-50%);
+}
+
+.poker-seat-1{
+  min-width: 30vh;
+  height: 32vh;
+  bottom: 1vh;
+  left: 50vw;
+  transform: translateX(-50%);
+  width: 16vw;
+  overflow-y: scroll;
+}
+.poker-seat-1 .hand {
+  display: none;
+}
+
+.poker-seat-4 .hand, .poker-seat-3 .hand, .poker-seat-2 .hand {
+  right: 15vh;
+  top: 2vh;
+}
+
+.poker-seat-5 .hand, .poker-seat-6 .hand {
+  left: 24vh;
+  top: 2vh;
+}
 
 
 /***************/


### PR DESCRIPTION
#253 done

I have changed the p1, p2, ... class names used to position players around a virtual table because they were conflicting with settlers and imperium using p1, p2... for color coding, so I updated all the card games (poker, hearts, president + blackjack via game-player-box) to use poker-seat-1, poker-seat-2... and updated the css selectors in game.css. The layout and gameplay of Imperium and Poker are (or should be) completely unaffected by the changes. 

Furthermore, it seems @trevelyan and I have been going back in forth in the css for positioning game-player-boxes (several rounds now), but I think this should sort things out. Even though I removed the id-based css selectors for playerboxes in game.css (which was messing up the wuziqi and settlers apps), gametestsuite still demonstrates playerboxes nicely.
 