### PR TITLE
fix: progress past overlay in app store publish

### DIFF
--- a/mods/appstore/lib/email-appspace/appstore-appspace-publish/appstore-publish-success/appstore-publish-success.js
+++ b/mods/appstore/lib/email-appspace/appstore-appspace-publish/appstore-publish-success/appstore-publish-success.js
@@ -12,7 +12,7 @@ module.exports = AppStorePublishSuccess = {
       app.browser.addElementToDom('<div id="appstore-app-install-overlay" class="appstore-app-install-overlay"></div>');
     }
 
-    document.querySelector('.appstore-app-install-overlay').innerHTML = AppStorePublishWaitingTemplate(app, data);
+    document.querySelector('.appstore-app-install-overlay').innerHTML = AppStorePublishWaitingTemplate(app, mod.data);
     document.querySelector('.appstore-app-install-overlay').style.display = "block";
 
 /**


### PR DESCRIPTION
Without this fix, proceeding through the tutorial you get stuck on a blank overlay screen (it never makes it to the 45-second countdown).